### PR TITLE
Put the ScrapeOrbit banner at the top of the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 <p align="center">
-  <b>Trouble with captchas? With proxies? Is your browser detected every time?</b><br>
-  <sub>Join the group and ask. Someone in there has already solved it.</sub>
+  <a href="https://feder-cr.github.io/invisible_playwright/"><img src="https://raw.githubusercontent.com/feder-cr/invisible_playwright/main/docs/scrapeorbit-demo.gif" alt="ScrapeOrbit - find and scrape any company on Earth" width="760"></a>
 </p>
 <p align="center">
-  <a href="https://t.me/scrapingtheweb"><img src="https://raw.githubusercontent.com/feder-cr/invisible_core/main/docs/badges/telegram.svg" alt="Join on Telegram" height="38"></a>
+  <b>Find and scrape any company on Earth.</b>
+</p>
+<p align="center">
+  <a href="https://feder-cr.github.io/invisible_playwright/"><img src="https://img.shields.io/badge/%E2%96%B6_Try_it_live-38f0c8?style=for-the-badge" alt="Try it live"></a>
 </p>
 
 <h2></h2>


### PR DESCRIPTION
Swaps the Telegram group promo at the top of the readme for the ScrapeOrbit banner and a single Try it live button.