### PR TITLE
20.15.0: la correzione del proxy arriva agli utenti

### DIFF
--- a/src/invisible_core/_version.py
+++ b/src/invisible_core/_version.py
@@ -9,7 +9,7 @@ reset it: pip compares with != , not <.
 import json
 import pathlib
 
-CORE_REVISION = 14
+CORE_REVISION = 15
 
 _seal = json.loads(
     pathlib.Path(__file__).with_name("seal.json").read_text(encoding="utf-8")


### PR DESCRIPTION
`CORE_REVISION` 14 -> 15. Rilascio di solo Python contro lo stesso motore: il sigillo resta `firefox-20`, il binario non si muove, nessuno deve riscaricare niente.

## Cosa porta

La correzione mergiata in #6, che su `main` c'era gia' ma sull'indice no. Il difetto e' vissuto in 17 versioni pubblicate, da v18.0.0 a v20.14.0: un endpoint `http://` o `https://` passato a `build_launch_plan` non produceva NESSUNA pref di proxy, perche' `configure_proxy` lo restituisce a chi la chiama e quel percorso, lanciando il binario con `subprocess`, non aveva dove metterlo. Il browser usciva dall'indirizzo della macchina mentre `_geo` aveva gia' risolto fuso, lingua ed egress ATTRAVERSO il proxy: la sessione dichiarava un paese e ne navigava un altro, senza sollevare niente.

## Chi deve fare cosa

| se usi | cosa cambia |
|---|---|
| `invisible_playwright` | niente. Non e' mai stato toccato: misurato, esce dall'IP del proxy sia in http sia in socks5 |
| `build_launch_plan` con SOCKS | niente |
| `build_launch_plan` con HTTP senza credenziali | ora viene instradato davvero, invece di essere ignorato |
| `build_launch_plan` con HTTP con credenziali | ora viene RIFIUTATO con un messaggio che dice dove funziona |

L'ultima riga e' una rottura voluta e visibile. E' l'unica alternativa onesta a uscire di nascosto dall'IP sbagliato: quel percorso lancia il binario direttamente, quindi non ha un Playwright che risponda al 407, e il browser non ha una pref che inietti `Proxy-Authorization` (solo i SOCKS ce l'hanno, per una nostra patch).

## Ordine

Questo va per primo. Il pin del consumatore e' gia' stato portato a `invisible_core==20.15.0` con `scripts/sync_core_pin.py`, ma il wrapper non puo' essere rilasciato finche' 20.15.0 non risponde dall'indice: il suo gate lo rifiuta, ed e' giusto cosi'.

Il gate del pin ha fermato il primo tentativo di push di questa PR, con `violated`, perche' avevo alzato la versione senza sincronizzare. Ha fatto esattamente quello per cui esiste.

913 test verdi, 0 skipped. e2e sul binario firefox-20: 144 verdi. `version_gate.py check`: PUBLISH ALLOWED.