### PR TITLE
Drop the ScrapeOrbit banner from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,3 @@
-<p align="center">
-  <a href="https://feder-cr.github.io/invisible_playwright/"><img src="https://raw.githubusercontent.com/feder-cr/invisible_playwright/main/docs/scrapeorbit-demo.gif" alt="ScrapeOrbit - find and scrape any company on Earth" width="760"></a>
-</p>
-<p align="center">
-  <b>Find and scrape any company on Earth.</b>
-</p>
-<p align="center">
-  <a href="https://feder-cr.github.io/invisible_playwright/"><img src="https://img.shields.io/badge/%E2%96%B6_Try_it_live-38f0c8?style=for-the-badge" alt="Try it live"></a>
-</p>
-
-<h2></h2>
-
 # invisible_core
 
 Pure config for a patched Firefox stealth profile - **zero Playwright dependency**.


### PR DESCRIPTION
Removes the banner block at the top of the README. The empty `<h2></h2>` under it went with it: it separated the promo block from the content, so without the block it is a horizontal rule above nothing.

Nothing else in the file changed - the new content is a byte-exact suffix of the old one.