### PR TITLE
Taggare era un modo di pubblicare codice che nessun job aveva eseguito

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -107,12 +107,35 @@ jobs:
         # was already on the index and `already-published` short-circuits
         # exactly that case. A workflow that only ever no-ops is green in the
         # same way an unexecuted branch is covered.
-        run: python -m pip install -e . --quiet
+        # `.[dev]` e non `-e .`: da oggi questo job esegue anche la suite (passo
+        # "la suite" qui sotto), e pytest sta nell'extra. Resta un extra di
+        # SVILUPPO in un job che NON ha credenziali: quelle vivono in `upload`,
+        # che continua a installare il minimo indispensabile.
+        run: python -m pip install -e ".[dev]" --quiet
       - name: the hooks are installed for anyone who clones this
         # The local pre-push layer is only real if .githooks is wired up. CI
         # cannot check somebody else's clone, but it can check that the wiring
         # this repo ships still works, so it cannot rot unnoticed.
         run: python scripts/install_hooks.py --check || python scripts/install_hooks.py
+      - name: la suite
+        # Un push di TAG non innesca il workflow ordinario dei test, che gira su
+        # rami e pull request. Senza questo passo, taggare e' un modo di
+        # pubblicare codice che nessun job ha eseguito.
+        #
+        # Il wrapper questo passo ce l'aveva dal 2026-08-01, con questa stessa
+        # motivazione scritta accanto; il core no, e nessun documento diceva
+        # perche'. Trovato il 2026-08-18 da un audit sui gate: `pytest` non
+        # compariva in tutto questo file.
+        #
+        # ⛔ La mitigazione che esisteva NON basta, ed e' bene sapere quale
+        # era: il hook di pre-push esegue la suite anche quando si spinge un
+        # tag - misurato, il push di v20.15.0 ha impiegato quattro minuti
+        # proprio per questo. Ma i hook sono locali. Un tag creato
+        # dall'interfaccia web, dall'API, o da un clone senza `core.hooksPath`
+        # non ne incontra nessuno, e i tag non sono coperti dalla protezione
+        # del ramo. Questo passo e' l'unico che sta dalla parte del server.
+        run: python -m pytest -q
+
       - name: version gate
         # Exit codes: 0 pass, 1 refused, 2 gate broken, 4 no usable ledger.
         # Only 0 continues, and --verify-index makes the ledger's claim get


### PR DESCRIPTION
## Il difetto

Il job `gate` di `publish.yml` faceva checkout, installava, controllava che i hook fossero cablati e lanciava `version_gate.py`, che confronta il registro con l'indice. **In tutto il file la parola `pytest` non compariva.** La suite gira in `ci.yml`, un workflow diverso, innescato da rami e pull request: un tag non lo innesca.

Trovato da un audit che ha letto 363 controlli chiedendo a ognuno se puo' essere verde mentre un rilascio e' a meta'.

## La ragione era gia' scritta qui dentro

Il wrapper ha il passo identico dal 2026-08-01, con il commento accanto:

> a tag push does not trigger the ordinary test workflow, which runs on branches and pull requests. Without this, tagging is a way to publish code no job has run.

Il core quel passo non ce l'aveva e nessun documento diceva perche'. Non era una scelta di disegno: i due `publish.yml` divergevano e basta.

## La mitigazione che esisteva, e perche' non basta

Il hook di pre-push esegue la suite anche quando si spinge un TAG: misurato, il push di `v20.15.0` ha impiegato quattro minuti proprio per quello. Quindi il buco non era "nessuno testa mai", era **"nessuno testa se il tag nasce fuori da un clone con i hook armati"** - dall'interfaccia web, dall'API, o da una copia senza `core.hooksPath`. E i tag non sono coperti dalla protezione del ramo.

Un controllo che dipende da come e' configurata la macchina di chi rilascia non e' un controllo del progetto.

## Perche' `.[dev]` nel gate e non in `upload`

`pytest` sta nell'extra di sviluppo, quindi il gate lo installa. `upload` continua a installare il minimo indispensabile: e' il job che possiede la credenziale OIDC e `contents: write`, e non deve tirarsi dentro pytest e ruff. Il suo commento lo dice gia'.

## Validato eseguendo, non leggendo

I quattro blocchi `run:` del job estratti dal YAML ed eseguiti in un venv nuovo:

| passo | esito |
|---|---|
| `pip install --upgrade pip build hatchling` | exit 0 |
| `pip install -e ".[dev]"` | exit 0 |
| `install_hooks.py --check` | exit 0 |
| **`pytest -q`** | **912 passati, 1 saltato**, 4m53s |

Il saltato e' il test del pin: senza il consumatore installato risponde `not-checkable`, che e' il percorso documentato ed e' quello che vedra' anche la CI.