### PR TITLE
Il README mandava i lettori su un sito che da 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Same seed → same fingerprint, every time.
 
 Which surfaces a browser fingerprint is made of, what each one gives away, and why
 consistency between them matters more than any single value, is written up at
-**[feder-cr.github.io/invisible_playwright](https://feder-cr.github.io/invisible_playwright/)**.
+**[the invisible_playwright wiki](https://github.com/feder-cr/invisible_playwright/wiki)**.
 Those pages are about the problem, not about this package, and several of them
 record something we got wrong first. A few that document the exact fields this
 package generates:


### PR DESCRIPTION
La riga sulla documentazione dei campi rimandava a `feder-cr.github.io/invisible_playwright`, e **Pages non esiste piu'**: l'API risponde 404 su tutti e tre i repo del progetto e il sito stesso da 404. Chi cercava di capire cosa siano i campi che questo pacchetto genera finiva sul nulla.

Ora punta al **wiki di invisible_playwright**, che risponde 200 e ospita lo stesso materiale organizzato.

## Come e' stato trovato

Controllando per intero la documentazione pubblica dei due pacchetti, non leggendola:

| cosa | esito |
|---|---|
| 2814 link relativi in 332 file `.md` | **zero rotti** |
| 42 URL assoluti verso repo nostri | 4 non-200, **2 difetti veri** |

Le pagine specifiche citate subito sotto questa riga, pinning e font multipiattaforma, erano gia' link diretti a `docs/` su `main` e funzionavano: era solo il rimando generale a essere rimasto indietro.

Dei quattro non-200, due non sono difetti: LinkedIn da 999, che e' il suo codice anti-bot, e `/stargazers` da 404 a un client non-browser mentre l'API ne conta 1901.

## Verifica

Tutti e nove gli URL nostri in questo README riverificati dopo la modifica: zero rotti.

## Un'osservazione che vale oltre questa correzione

I controlli automatici del progetto sorvegliano i puntatori **dentro** i documenti - `check_index.py` - ed e' per questo che 2814 link relativi sono sani. Niente sorveglia cio' che **esce** dal repo, e tutti e tre i guasti trovati oggi stavano esattamente li': un sito spento, un file cancellato da `main`, un tag mai creato. Sono le tre cose che un gate sui file non puo' vedere per costruzione.