### PR TITLE
Il revert del newtab, le chiavi API e la posizione dichiarata

### DIFF
--- a/src/invisible_core/_geo.py
+++ b/src/invisible_core/_geo.py
@@ -160,6 +160,56 @@ def discover_egress_ip(
     )
 
 
+def _geo_record(ip: str, mmdb_path: Any) -> "Optional[Dict[str, Any]]":
+    """L'UNICO punto che apre il database e legge un record.
+
+    Le tre funzioni qui sotto - fuso, locale e coordinate - leggono lo STESSO
+    record dello STESSO IP, e prima di questa funzione due di loro ripetevano
+    le stesse tre righe. Aggiungere la terza avrebbe fatto tre copie di come si
+    legge il database, che e' la regola 16 violata mentre la si applica.
+
+    Torna ``None`` se l'IP non c'e': chi chiama decide se e' fatale (il fuso,
+    che dietro un proxy deve fallire rumorosamente) o no (il locale, che ha un
+    ripiego dichiarato).
+    """
+    import maxminddb
+
+    with maxminddb.open_database(str(mmdb_path)) as reader:
+        record = reader.get(ip)
+    return record if isinstance(record, dict) else None
+
+
+def ip_to_coordinates(ip: str, mmdb_path: Any) -> "tuple[float, float]":
+    """Map ``ip`` -> (latitudine, longitudine) dallo stesso record del fuso.
+
+    ⛔ E' la fonte UNICA della posizione dichiarata: il motore non chiede piu'
+    niente all'hardware (niente WiFi, niente GPS, niente cella) e non chiede
+    niente a Google. La posizione esce dall'IP di uscita del proxy, esattamente
+    come il fuso e la lingua, quindi le tre cose non possono contraddirsi.
+
+    ⛔ LA PRECISIONE NON VIENE DA QUI, e non e' una dimenticanza: misurato il
+    2026-08-20 su un record vero, ``location`` porta ``latitude``,
+    ``longitude`` e ``time_zone`` e **non** ``accuracy_radius``. Dichiararla e'
+    un'altra decisione, e vive nel Profile: una posizione derivata da un IP con
+    una precisione da GPS sarebbe incoerente per costruzione.
+
+    Solleva :class:`GeoTimezoneError` - stessa classe del fuso, perche' e' lo
+    stesso guasto - se l'IP manca o il record non porta le coordinate. **Non si
+    inventa un ripiego**: senza dichiarazione il motore rifiuta, che e' la
+    regola 7.
+    """
+    record = _geo_record(ip, mmdb_path)
+    if not record:
+        raise GeoTimezoneError(f"egress IP {ip} not present in the geoip database")
+    loc = record.get("location") or {}
+    lat, lon = loc.get("latitude"), loc.get("longitude")
+    if lat is None or lon is None:
+        raise GeoTimezoneError(
+            f"no coordinates for egress IP {ip} in the geoip database"
+        )
+    return float(lat), float(lon)
+
+
 def ip_to_timezone(ip: str, mmdb_path: Any) -> str:
     """Map ``ip`` to its IANA timezone using the offline mmdb.
 
@@ -167,15 +217,10 @@ def ip_to_timezone(ip: str, mmdb_path: Any) -> str:
     against the system tz database. Raises :class:`GeoTimezoneError` if the IP
     is absent from the DB or the zone is missing / not a valid IANA name.
     """
-    import maxminddb
-
-    with maxminddb.open_database(str(mmdb_path)) as reader:
-        record = reader.get(ip)
+    record = _geo_record(ip, mmdb_path)
     if not record:
         raise GeoTimezoneError(f"egress IP {ip} not present in the geoip database")
-    tz = ((record.get("location") or {}) if isinstance(record, dict) else {}).get(
-        "time_zone"
-    )
+    tz = (record.get("location") or {}).get("time_zone")
     if not tz:
         raise GeoTimezoneError(f"no timezone for egress IP {ip} in the geoip database")
     from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -252,13 +297,8 @@ def ip_to_locale(ip: str, mmdb_path: Any) -> str:
     """Map ``ip`` -> a BCP-47 locale via the MaxMind ``country.iso_code`` field, so the
     browser language stays consistent with the proxy egress country. Falls back to
     ``en-US`` for IPs absent from the DB or countries we don't map."""
-    import maxminddb
-
-    with maxminddb.open_database(str(mmdb_path)) as reader:
-        record = reader.get(ip)
-    cc = ""
-    if isinstance(record, dict):
-        cc = ((record.get("country") or {}).get("iso_code") or "")
+    record = _geo_record(ip, mmdb_path)
+    cc = ((record.get("country") or {}).get("iso_code") or "") if record else ""
     return _COUNTRY_LOCALE.get(cc.upper(), "en-US")
 
 
@@ -320,6 +360,16 @@ class SessionGeo(NamedTuple):
 
     timezone: str
     egress_ip: Optional[str]
+    #: La posizione dichiarata, dallo STESSO record dell'IP di uscita da cui
+    #: escono fuso e lingua. ``None`` quando non c'e' un IP da cui derivarla
+    #: (nessun proxy, o scoperta fallita): in quel caso il motore NON riceve
+    #: nessuna dichiarazione e rifiuta, invece di chiedere all'hardware.
+    #:
+    #: Hanno un default perche' ``SessionGeo`` si costruisce per posizione con
+    #: due argomenti in sei punti fra codice e test: aggiungerli senza default
+    #: sarebbe stato un cambiamento non retrocompatibile di un tipo esportato.
+    latitude: Optional[float] = None
+    longitude: Optional[float] = None
 
 
 def prepare_session_geo(
@@ -350,13 +400,31 @@ def prepare_session_geo(
             egress_err = exc
 
     # Timezone resolution - same precedence as resolve_session_timezone.
+    def _coordinate(ip: "Optional[str]") -> "tuple[Optional[float], Optional[float]]":
+        """Le coordinate sono BEST-EFFORT, il fuso no, e la differenza e' voluta.
+
+        Un fuso sbagliato dietro un proxy e' la trappola `tz_mismatch` e deve
+        far fallire il lancio. Una posizione ASSENTE invece non e' una
+        contraddizione: e' un browser a cui nessuno ha ancora chiesto dove sia,
+        e il motore la rifiuta in modo pulito. Far fallire il lancio per questo
+        sarebbe piu' fragile senza essere piu' fedele.
+        """
+        if not ip:
+            return None, None
+        try:
+            return ip_to_coordinates(ip, ensure_geoip_mmdb())
+        except Exception:  # noqa: BLE001
+            return None, None
+
     if tz and tz.lower() != "auto":
-        return SessionGeo(tz, egress_ip)  # explicit IANA wins
+        lat, lon = _coordinate(egress_ip)
+        return SessionGeo(tz, egress_ip, lat, lon)  # explicit IANA wins
     try:
         ip = egress_ip if proxy_set else discover_egress_ip(None)
         if ip is None:  # proxy set but discovery failed above
             raise egress_err or GeoTimezoneError("egress IP discovery failed")
-        return SessionGeo(ip_to_timezone(ip, ensure_geoip_mmdb()), egress_ip)
+        lat, lon = _coordinate(ip)
+        return SessionGeo(ip_to_timezone(ip, ensure_geoip_mmdb()), egress_ip, lat, lon)
     except Exception:
         if proxy_set:
             raise  # fail-early behind a proxy (timezone_mismatch trap)

--- a/src/invisible_core/download.py
+++ b/src/invisible_core/download.py
@@ -405,8 +405,13 @@ def ensure_binary(version: str | None = None, progress=None, status=None,
     if seal.is_local:
         raise SealError(
             f"the active seal ({seal.origin}) is a LOCAL seal with no published assets, "
-            f"so there is nothing to download. Point binary_path= / INVPW_BINARY_PATH at "
-            f"the tree this seal was generated from.")
+            f"so there is nothing to download. Pass binary_path= pointing at the "
+            f"build this seal was generated from. "
+            f"(INVPW_BINARY_PATH is NOT read by this library - the test scripts and "
+            f"run_e2e.py translate it into binary_path=, so it only works under them. "
+            f"Corrected 2026-08-19; the same false promise was removed from "
+            f"invisible_playwright/_engine.py on 2026-08-14, and naming an env var "
+            f"the code never reads sends the reader hunting in the wrong function.)")
 
     plat = sys.platform
     asset = seal.asset_for(plat, platform.machine())

--- a/src/invisible_core/launch.py
+++ b/src/invisible_core/launch.py
@@ -269,7 +269,19 @@ def build_launch_plan(
     pin: Optional[Dict[str, Any]] = None,
     binary_ver: Optional[str] = None,
     extra_args: Optional[List[str]] = None,
-    url: str = "about:blank",
+    # ⛔ IL DEFAULT ERA "about:blank", TOLTO IL 2026-08-20 col revert del newtab.
+    # Un URL sulla riga di comando ha la PRECEDENZA sulla pagina d'avvio, quindi
+    # finche' c'era il lancio diretto non apriva about:home nemmeno con i cinque
+    # file del sorgente riportati a upstream e le prefs newtab tolte: era la
+    # seconda soppressione, indipendente da `browser.startup.page`.
+    #
+    # E ne chiude anche un'altra, misurata il 2026-08-20: un URL iniziale spegne
+    # le chiamate ad `accounts.firefox.com` e `addons.mozilla.org` che il retail
+    # fa all'avvio (2/2 senza URL, 0/2 con). Su Playwright quell'argomento lo
+    # impone la libreria e non e' nostro; QUI era nostro, ed era una scelta.
+    #
+    # Il parametro resta pubblico: chi vuole una pagina la passa esplicitamente.
+    url: str = "",
 ) -> LaunchPlan:
     """The single direct-launch entry point (no Playwright, no Qt).
 

--- a/src/invisible_core/prefs.py
+++ b/src/invisible_core/prefs.py
@@ -454,7 +454,15 @@ _BASELINE: Dict[str, Any] = {
     # Safebrowsing - chatty and fingerprintable.
 
     # First-run / welcome UI noise.
-    "browser.startup.page":                               0,
+    #
+    # ⛔ QUI STAVA `browser.startup.page: 0`, TOLTA IL 2026-08-20 col revert del
+    # newtab. Era l'ULTIMO punto vivo che sopprimeva about:home: con 0 la finestra
+    # iniziale parte vuota anche con i cinque file del sorgente riportati a
+    # upstream e le cinque prefs newtab tolte, quindi il revert sarebbe stato
+    # completo a meta' e la pagina non si sarebbe vista lo stesso. Il default di
+    # Gecko e' 1, cioe' la home page, che e' cio' che fa un retail.
+    # Le tre righe qui sotto restano: sono la finestra di benvenuto e il
+    # controllo del browser predefinito, che sono un'altra cosa dal newtab.
     "browser.shell.checkDefaultBrowser":                  False,
     "browser.aboutwelcome.enabled":                       False,
     "browser.startup.upgradeDialog.enabled":              False,
@@ -481,14 +489,88 @@ _BASELINE: Dict[str, Any] = {
     # zero mousedown, zero mousemove - mentre la tastiera continua a funzionare.
     # Questa riga sembrava proteggerci e non proteggeva niente.
 
-    # Disable about:newtab auto-load - TopSitesFeed.sys.mjs auto-fetches when
-    # a tab opens, triggering a cross-process BC swap that hijacks the first
-    # page.goto() (NS_BINDING_ABORTED on creepjs/peet/sannysoft/fppro).
-    "browser.newtabpage.enabled":                         False,
-    "browser.newtab.preload":                             False,
-    "browser.newtabpage.activity-stream.feeds.topsites":  False,
-    "browser.newtabpage.activity-stream.feeds.section.topstories": False,
-    "browser.newtabpage.activity-stream.enabled":         False,
+    # ⛔ LE CINQUE PREFS DEL NEWTAB SONO STATE TOLTE (2026-08-20), ED E' UNA
+    # DECISIONE DEL PROPRIETARIO: "voglio riavere il codice originale, dei 34mb
+    # rimettere questo processo in piedi". Erano queste:
+    #
+    #   browser.newtabpage.enabled                                   False
+    #   browser.newtab.preload                                       False
+    #   browser.newtabpage.activity-stream.feeds.topsites            False
+    #   browser.newtabpage.activity-stream.feeds.section.topstories  False
+    #   browser.newtabpage.activity-stream.enabled                   False
+    #
+    # La seconda e' quella che teneva GIU' il processo preallocato della nuova
+    # scheda, quindi senza toglierla il revert del sorgente non bastava: i
+    # cinque file di Firefox sono tornati a upstream, ma il processo sarebbe
+    # rimasto spento da qui. Ora il retail e noi partiamo dagli stessi default.
+    #
+    # ⛔ LA REGRESSIONE E' TORNATA IL 2026-08-23, ED E' STATA CHIUSA NEL MOTORE:
+    # queste righe restano tolte e non vanno rimesse.
+    #
+    # Il segnale era quello previsto - la PRIMA `page.goto()` che muore, non le
+    # successive - ma con un altro messaggio: "Navigation ... interrupted by
+    # another navigation to about:newtab", e subito dopo, se si aspettava,
+    # "can't access property loadURI, browsingContext is undefined". Il gate
+    # `fppro_full` falliva 2 volte su 2.
+    #
+    # ⛔ E LA DIAGNOSI SCRITTA QUI SOPRA ERA SBAGLIATA IN DUE PUNTI, misurati
+    # entrambi quel giorno con Playwright puro sullo stesso binario:
+    #
+    #  1. Non e' la fetch di `TopSitesFeed`. E' il browser PREALLOCATO della
+    #     nuova scheda: `JugglerFrameParent` riconosceva il target confrontando
+    #     `browserId` con l'`id` di un BrowsingContext - due contatori diversi -
+    #     e con browserId 12 contro bcId 12 quel browser estraneo si prendeva il
+    #     canale della pagina. Da fuori si vedeva un secondo
+    #     `Page.frameAttached mainframe-12` sulla stessa sessione.
+    #  2. **Aspettare NON e' il rimedio**, ed era la riga che stava qui. Con
+    #     l'attesa vera - non un ritardo fisso: si aspettava che `about:newtab`
+    #     fosse arrivato E caricato - la `goto` successiva riusciva **0 volte su
+    #     9**, perche' a quel punto il frame che il client crede principale non
+    #     esiste sotto il browser della scheda. Il ritardo di 0,4 s che il
+    #     wrapper aveva riusciva solo quando VINCEVA LA CORSA, cioe' a caso.
+    #
+    # Il rimedio sta dove sta la causa: `juggler/JugglerFrameParent.sys.mjs`
+    # smentisce il riconoscimento numerico con l'elemento `<browser>` a cui il
+    # contesto appartiene. Con quello, e con la preallocazione ACCESA come vuole
+    # il proprietario, 10 giri su 10 riusciti e nessun mainframe di troppo.
+    # I numeri per esteso in `70-known-bugs.md` [B166].
+
+    # ══════════════════════════════════════════════════════════════════════
+    #  LE TRE CHIAVI API, DICHIARATE QUI E IN NESSUN ALTRO POSTO
+    # ══════════════════════════════════════════════════════════════════════
+    #
+    # Decisione del proprietario, 2026-08-20: "voglio portare questi valori su
+    # invisible_core, trova il modo che ogni volta che firefox si avvia li legga
+    # e li setti prendendoli da invisible_core, come stiamo fondamentalmente
+    # facendo per tutte le altre cose che invisible_core genera".
+    #
+    # PRIMA: erano incise nel binario a tempo di compilazione. `configure`
+    # leggeva tre keyfile da $APIKEYDIR e sostituiva `@MOZ_..._API_KEY@` dentro
+    # `AppConstants.sys.mjs`, che a runtime e' una costante congelata.
+    #
+    # ADESSO: quel percorso non esiste piu' - tolte le tre voci di
+    # AppConstants.sys.mjs, i tre DEFINES di toolkit/modules/moz.build e le tre
+    # --with-*-api-keyfile del .mozconfig - e il solo lettore del motore,
+    # `URLFormatter.sys.mjs`, legge queste pref (`stealthDeclaredApiKey`).
+    #
+    # ⛔ E L'ASSENZA SI RIFIUTA. Senza dichiarazione il motore torna la stringa
+    # vuota e registra un errore in console: `checkGoogleSafeBrowsingKey` la
+    # legge come falsy e SPEGNE il provider, quindi non parte nessuna richiesta
+    # con una chiave finta o con un segnaposto dentro. E' la regola 7: se la
+    # dichiarazione manca si rifiuta, non si inventa un default.
+    #
+    # ⛔ I VALORI SONO QUELLI DI MOZILLA, byte per byte, ed e' deliberato.
+    # Il proprietario, 2026-08-20: "devono essere byte per byte identiche a
+    # quelle dentro il Firefox scaricato dal loro sito". Sono le stesse chiavi
+    # che ogni Firefox retail porta gia' in chiaro dentro `omni.ja`, quindi
+    # dichiararle qui non pubblica niente che non sia gia' pubblico - ma resta
+    # una scelta, non un dettaglio, ed e' scritta qui perche' si veda.
+    #
+    # Il dominio e' FINITO E NOTO - tre chiavi - quindi la regola 2 e'
+    # soddisfatta e la regola 1 si applica: il core dichiara, il motore obbedisce.
+    "zoom.stealth.apikey.google_location_service": "AIzaSyB0mAay6Zu8JTU8XTQtXJLri9eY9wISq6o",
+    "zoom.stealth.apikey.google_safebrowsing":     "AIzaSyC7jsptDS3am4tPx4r3nxis7IMjBc5Dovo",
+    "zoom.stealth.apikey.mozilla":                 "7e40f68c-7938-4c5d-9f95-e61647c213eb",
 
     # Disable Firefox internal services that hit the network on startup.
     # Through a residential SOCKS5 proxy these compete with the test

--- a/src/invisible_core/prefs.py
+++ b/src/invisible_core/prefs.py
@@ -452,17 +452,34 @@ _BASELINE: Dict[str, Any] = {
     "security.ssl3.ecdhe_ecdsa_aes_128_sha":              False,
 
     # Safebrowsing - chatty and fingerprintable.
-    "browser.safebrowsing.malware.enabled":               False,
-    "browser.safebrowsing.phishing.enabled":              False,
-    "browser.safebrowsing.downloads.enabled":             False,
-    "browser.safebrowsing.downloads.remote.enabled":      False,
 
     # First-run / welcome UI noise.
     "browser.startup.page":                               0,
     "browser.shell.checkDefaultBrowser":                  False,
     "browser.aboutwelcome.enabled":                       False,
     "browser.startup.upgradeDialog.enabled":              False,
-    "termsofuse.acceptedVersion":                         999,
+    # ⛔ QUI STAVA `termsofuse.acceptedVersion: 999`, ED ERA UNA DICHIARAZIONE
+    # MORTA. Tolta il 2026-08-19 dopo averla misurata, non dedotta.
+    #
+    # Non faceva niente per due ragioni indipendenti, e ognuna basta:
+    #  1. duplicava il default upstream: browser/app/profile/firefox.js
+    #     dichiara gia' termsofuse.acceptedVersion a 999 di suo.
+    #  2. da sola non sarebbe bastata comunque. hasUserAcceptedCurrentTOU
+    #     (TelemetryReportingPolicy.sys.mjs:536) vuole ANCHE
+    #     termsofuse.acceptedDate non nulla, e upstream la mette a "0".
+    #     Misurato: con la sola versione il modale esce lo stesso.
+    #
+    # E non e' riparabile da qui in nessun caso: le prefs di questo dizionario
+    # viaggiano sul protocollo e Browser.enable le applica DOPO l'avvio, mentre
+    # il modale nasce con la finestra. Misurato: le stesse prefs passate come
+    # firefox_user_prefs non riparano, scritte in un user.js prima del lancio
+    # riparano. Il rimedio vive nel default compilato del nostro Firefox:
+    # browser/app/profile/firefox.js, termsofuse.acceptedDate.
+    #
+    # Cosa costava tenerla: su una build MOZILLA_OFFICIAL il modale dei termini
+    # d'uso copre il viewport e mangia OGNI evento di mouse - fuoco su BODY,
+    # zero mousedown, zero mousemove - mentre la tastiera continua a funzionare.
+    # Questa riga sembrava proteggerci e non proteggeva niente.
 
     # Disable about:newtab auto-load - TopSitesFeed.sys.mjs auto-fetches when
     # a tab opens, triggering a cross-process BC swap that hijacks the first
@@ -479,8 +496,6 @@ _BASELINE: Dict[str, Any] = {
     # connection drops). Domains observed in MOZ_LOG: push.services,
     # firefox.settings.services, detectportal, ohttp-gateway, location.
     "browser.aboutConfig.showWarning":                    False,
-    "network.captive-portal-service.enabled":             False,
-    "network.connectivity-service.enabled":               False,
     # [CORRETTO 2026-08-09] These three were False, and the reason above is the
     # reason they were: startup network chatter through a residential proxy.
     # But turning them off DELETES Web APIs from the page. Measured against
@@ -496,7 +511,6 @@ _BASELINE: Dict[str, Any] = {
     # it, which the default-deny below answers locally. A user who blocked
     # location is the most ordinary thing on the web.
     "dom.push.enabled":                                   True,
-    "dom.push.connection.enabled":                        False,
     "geo.enabled":                                        True,
     #: `permissions.default.geo` is deliberately NOT SET, and this comment is
     #: here so nobody adds it back for the reason it was added the first time.
@@ -554,15 +568,8 @@ _BASELINE: Dict[str, Any] = {
     "browser.search.geoSpecificDefaults":                 False,
     "browser.contentblocking.report.lockwise.enabled":    False,
     "browser.contentblocking.report.monitor.enabled":     False,
-    "extensions.systemAddon.update.enabled":              False,
-    "extensions.update.enabled":                          False,
-    "extensions.getAddons.cache.enabled":                 False,
-    "browser.discovery.enabled":                          False,
-    "browser.ping-centre.telemetry":                      False,
-    "app.normandy.enabled":                               False,
     "dom.private-attribution.submission.enabled":         False,
     "browser.translations.enable":                        False,
-    "browser.search.update":                              False,
 
     # HTTP/3 + speculative + Alt-Svc disabled. SOCKS5 proxy doesn't
     # support UDP ASSOCIATE so HTTP/3 fails. Speculative connections
@@ -571,7 +578,6 @@ _BASELINE: Dict[str, Any] = {
     "network.http.http3.enabled":                         False,
     "network.http.altsvc.enabled":                        False,
     "network.http.altsvc.oe":                             False,
-    "network.http.speculative-parallel-limit":            0,
     "network.predictor.enabled":                          False,
     "network.dns.disablePrefetch":                        True,
     "network.dns.disablePrefetchFromHTTPS":               True,
@@ -605,14 +611,69 @@ _BASELINE: Dict[str, Any] = {
 
 
     # Telemetry & data reporting.
-    "datareporting.healthreport.uploadEnabled":           False,
-    "datareporting.policy.dataSubmissionEnabled":         False,
-    "toolkit.telemetry.enabled":                          False,
-    "toolkit.telemetry.unified":                          False,
-    "app.shield.optoutstudies.enabled":                   False,
+
+    # ------------------------------------------------------------------
+    # ⛔ QUI NON C'E' NIENTE, ED E' UNA DECISIONE - non una dimenticanza.
+    # Proprietario, 2026-08-19: il prodotto deve fare esattamente cio' che fa
+    # un Firefox retail, quindi le prefs che sopprimevano traffico che il
+    # retail fa sono state TOLTE, non impostate al valore del retail. Togliere
+    # eredita il default di Gecko, che e' per definizione quello del retail;
+    # impostare lascia un valore nostro che puo' divergere quando upstream
+    # cambia idea.
+    #
+    # Tolte qui: browser.safebrowsing.{malware,phishing,downloads,
+    # downloads.remote}.enabled, toolkit.telemetry.{enabled,unified},
+    # datareporting.{healthreport.uploadEnabled,policy.dataSubmissionEnabled},
+    # app.{update.enabled,normandy.enabled,shield.optoutstudies.enabled},
+    # extensions.{update,systemAddon.update,getAddons.cache}.enabled,
+    # browser.{discovery.enabled,ping-centre.telemetry,search.update},
+    # network.{captive-portal-service,connectivity-service}.enabled,
+    # dom.push.connection.enabled, network.http.speculative-parallel-limit.
+    #
+    # ⛔ E NON VANNO RIDICHIARATE "per sicurezza" al valore del retail: sul
+    # percorso Juggler - quello che usa il prodotto - PLAYWRIGHT NON SCRIVE
+    # NESSUNA PREF. Il blocco delle ~86 che si trova cercando in giro vive in
+    # `bidi/bidiFirefox.ts` e si raggiunge solo con `channel` che inizia per
+    # `moz-`, che noi non passiamo mai; la classe base ha `prepareUserDataDir`
+    # col corpo VUOTO. Misurato: un profilo Playwright nudo ha 48 prefs, tutte
+    # e 48 presenti anche nel profilo del retail firmato, e nessun `user.js`.
+    #
+    # `app.update.enabled` non e' fra queste per scelta: e' una pref MORTA,
+    # rimossa da Firefox (UpdateTelemetry.sys.mjs:54). La impostavamo a vuoto.
+    # Cio' che impedisce davvero l'installazione e' `app.update.auto`, che
+    # resta a False qui sotto: il retail CONTROLLA e noi pure, ma non
+    # scarichiamo e non installiamo, perche' installare distruggerebbe il
+    # binario pinnato dal sigillo.
+    #
+    # Contesto completo: docs/firefox-stealth-architecture/27-retail-network-parity.md
+    # ------------------------------------------------------------------
+
+    # ⛔ L'UNICA ECCEZIONE ALLA PARITA', E RESTA FINCHE' LA BUILD NON HA LA CHIAVE.
+    # Misurato nel sorgente 2026-08-19, catena completa:
+    #   browser.safebrowsing.downloads.remote.url =
+    #     https://sb-ssl.google.com/safebrowsing/clientreport/download
+    #       ?key=%GOOGLE_SAFEBROWSING_API_KEY%          (all.js:3448)
+    #   letta via FormatURLPref                          (ApplicationReputation.cpp:1603-1606)
+    #     -> la sentinella `no-google-safebrowsing-api-key` finisce NELLA URL
+    #   SendRemoteQueryInternal rifiuta solo URL vuoto o about:blank: la chiave
+    #     non la controlla mai.
+    # Quindi con questa pref ereditata a `true` e senza chiave vera, OGNI
+    # download binario manda a Google una POST con la sentinella dentro la
+    # query. Nessun retail emette quella stringa: non e' un'assenza, e' un
+    # segnale positivo che ci dichiara build senza chiave, verso il destinatario
+    # che stiamo cercando di non insospettire.
+    #
+    # Il percorso degli AGGIORNAMENTI LISTA e' protetto e non ha questo problema:
+    # checkGoogleSafeBrowsingKey azzera updateURL e gethashURL quando la chiave
+    # manca (SafeBrowsing.sys.mjs:537-568, :637-643). Solo la reputazione dei
+    # download scavalca il controllo.
+    #
+    # ⛔ SI TOGLIE QUANDO `--with-google-safebrowsing-api-keyfile` e' in vigore
+    # nella build: da quel momento questa riga diventa essa stessa la divergenza.
+    # Il gancio condizionale e' gia' nel .mozconfig di firefox-21.
+    "browser.safebrowsing.downloads.remote.enabled":      False,
 
     # Update channels.
-    "app.update.enabled":                                 False,
     "app.update.auto":                                    False,
 
     # Media devices: a FIXED pair (one audioinput, one videoinput) on every
@@ -807,16 +868,112 @@ _WIN_VIRT_DESKTOP_WORKAROUNDS: Dict[str, Any] = {
 #  Public helpers
 # ──────────────────────────────────────────────────────────────────────
 
+#: La tabella con cui Firefox costruisce `intl.accept_languages` di default,
+#: portata da `intl/locale/rust/locale_service_glue/src/lib.rs:89-222`
+#: (`locale_service_default_accept_languages`). Chiave = codice di LINGUA, non
+#: il locale intero.
+_ACCEPT_LANG_TABLE = {
+    "ace": "ace, id", "ach": "ach, en-GB", "af": "af, en-ZA, en-GB",
+    "ak": "ak, ak-GH", "an": "an, es-ES, es, ca", "ast": "ast, es-ES, es",
+    "az": "az-AZ, az", "bo": "bo-CN, bo-IN, bo", "br": "br, fr-FR, fr",
+    "brx": "brx, as", "bs": "bs-BA, bs", "cak": "cak, kaq, es",
+    "crh": "tr-TR, tr", "cs": "cs, sk", "csb": "csb, csb-PL, pl",
+    "cy": "cy-GB, cy", "dsb": "dsb, hsb, de", "el": "el-GR, el",
+    "et": "et, et-EE", "fa": "fa-IR, fa", "ff": "ff, fr-FR, fr, en-GB",
+    "fi": "fi-FI, fi", "fr": "fr, fr-FR", "frp": "frp, fr-FR, fr",
+    "fur": "fur-IT, fur, it-IT, it", "fy": "fy-NL, fy, nl",
+    "ga": "ga-IE, ga, en-IE, en-GB", "gd": "gd-GB, gd, en-GB",
+    "gl": "gl-ES, gl", "gn": "gn, es", "gv": "gv, en-GB", "he": "he, he-IL",
+    "hr": "hr, hr-HR", "hsb": "hsb, dsb, de",
+    "hto": "es-MX, es-ES, es, es-AR, es-CL", "hu": "hu-HU, hu",
+    "hye": "hye, hy", "ilo": "ilo-PH, ilo", "it": "it-IT, it",
+    "ixl": "ixl, es-MX, es", "ja": "ja", "ka": "ka-GE, ka",
+    "kab": "kab-DZ, kab, fr-FR, fr", "kk": "kk, ru, ru-RU", "kn": "kn-IN, kn",
+    "ko": "ko-KR, ko", "lb": "lb, de-DE, de", "lg": "lg, en-GB",
+    "lij": "lij, it", "lt": "lt, ru, pl", "ltg": "ltg, lv",
+    "mai": "mai, hi-IN, en", "meh": "meh, es-MX, es", "mix": "mix, es-MX, es",
+    "mk": "mk-MK, mk", "ml": "ml-IN, ml", "mr": "mr-IN, mr",
+    "nb": "nb-NO, nb, no-NO, no, nn-NO, nn",
+    "nn": "nn-NO, nn, no-NO, no, nb-NO, nb", "nr": "nr-ZA, nr, en-ZA, en-GB",
+    "nso": "nso-ZA, nso, en-ZA, en-GB", "oc": "oc, ca, fr, es, it",
+    "pa": "pa, pa-IN", "ppl": "ppl, es-MX, es", "rm": "rm, rm-CH, de-CH, de",
+    "ru": "ru-RU, ru", "sah": "sah, ru-RU, ru", "sc": "sc, it-IT, it",
+    "scn": "scn, it-IT, it", "si": "si-LK, si", "sk": "sk, cs",
+    "son": "son, son-ML, fr", "sq": "sq, sq-AL", "sr": "sr-RS, sr",
+    "st": "st-ZA, st, en-ZA, en-GB", "ta": "ta-IN, ta", "te": "te-IN, te",
+    "tl": "tl-PH, tl", "tr": "tr-TR, tr", "trs": "trs, es-MX, es",
+    "ts": "ts-ZA, ts, en-ZA, en-GB", "uk": "uk-UA, uk", "ur": "ur-PK, ur",
+    "uz": "uz, ru", "ve": "ve-ZA, ve, en-ZA, en-GB", "vi": "vi-VN, vi",
+    "xcl": "xcl, hy", "xh": "xh-ZA, xh", "zam": "zam, es-MX, es",
+}
+
+#: Le SEI lingue in cui Firefox NON aggiunge ", en-US, en" in coda
+#: (`add_en_us = false` nel sorgente citato sopra). Tutte le altre lo aggiungono.
+_ACCEPT_LANG_SENZA_EN = {
+    "en": None,          # la tabella per `en` dipende dalla regione, vedi sotto
+    "my": "my, en-GB, en",
+    "ro": "ro-RO, ro-GB, en",
+    "sco": "sco, en-GB, en",
+    "sl": "sl, en-GB, en",
+    "szl": "szl, pl-PL, pl, en, de",
+}
+
+
 def _accept_language(locale: str) -> str:
-    # "<locale>, <base>" - the desktop-default shape (e.g. "en-US, en"). Firefox expands it
-    # to navigator.languages=["en-US","en"] AND (via the patched binary) the q-valued header
-    # "en-US,en;q=0.5". The patched nsHttpHandler (STEALTHFOX, RE 2026-06-23) builds the
-    # Accept-Language header from THIS pref even when juggler sets a per-context locale
-    # override, so header and navigator.languages stay consistent 2/2 - the most authentic
-    # (real desktop) form. Supersedes the 2026-06-22 single-tag workaround.
+    """`intl.accept_languages` esattamente come lo costruisce Firefox 151.
+
+    ⛔ QUESTA FUNZIONE RESTITUIVA DUE VOCI PER OGNI LOCALE, E PER 89 LINGUE SU 95
+    ERA SBAGLIATO. Restituiva `"<locale>, <base>"` con il commento "la forma di
+    default del desktop (es. `en-US, en`)". Quella forma e' giusta **solo per
+    l'inglese**, che e' una delle sei lingue in cui Firefox non aggiunge la coda.
+
+    Il sorgente e' `locale_service_default_accept_languages`
+    (`intl/locale/rust/locale_service_glue/src/lib.rs:82-234`) e fa due cose:
+    una TABELLA di casi speciali per lingua, e poi
+
+        if add_en_us { format!("{langs}, en-US, en") } else { langs }
+
+    con `add_en_us` VERO di default e falso solo per en, my, ro, sco, sl, szl.
+    Il ramo di default della tabella e' `"{lang}-{region}, {lang}"`, cioe'
+    esattamente la nostra vecchia formula: mancava solo la coda, che e' il pezzo
+    che si vede.
+
+    Cosa costava, misurato: un profilo italiano emetteva
+        it-IT,it;q=0.9
+    dove un Firefox italiano vero emette
+        it-IT,it;q=0.9,en-US;q=0.8,en;q=0.7
+    su OGNI richiesta HTTP e in `navigator.languages`.
+
+    ⛔ E PERCHE' NON ERA STATO VISTO: il confronto col retail era stato fatto
+    contro una build **en-US**, cioe' l'unico caso in cui la vecchia formula e
+    quella vera coincidono per costruzione. Il braccio di controllo era scelto
+    male, non la misura sbagliata. Quando si confronta una funzione che dipende
+    da un parametro, il braccio non puo' stare sul valore in cui il difetto si
+    annulla.
+    """
     lang = locale.replace("_", "-")
-    base = lang.split("-")[0]
-    return f"{lang}, {base}" if base != lang else lang
+    pezzi = lang.split("-")
+    base = pezzi[0]
+    regione = pezzi[1] if len(pezzi) > 1 else None
+
+    if base == "en":
+        # unico ramo con sotto-casi per regione, e senza coda
+        return {"CA": "en-CA, en-US, en", "GB": "en-GB, en",
+                "ZA": "en-ZA, en-GB, en-US, en"}.get(regione, "en-US, en")
+    if base in _ACCEPT_LANG_SENZA_EN:
+        return _ACCEPT_LANG_SENZA_EN[base]
+
+    if base == "ca" and "valencia" in lang.lower():
+        langs = "ca-valencia, ca"
+    elif base == "zh" and regione == "CN":
+        langs = "zh-CN, zh, zh-TW, zh-HK"
+    elif base in _ACCEPT_LANG_TABLE:
+        langs = _ACCEPT_LANG_TABLE[base]
+    elif regione:
+        langs = f"{base}-{regione}, {base}"
+    else:
+        langs = base
+    return f"{langs}, en-US, en"
 
 
 def _accept_language_header(locale: str) -> str:
@@ -1334,9 +1491,27 @@ def _apply_locale(prefs: Dict[str, Any], locale: str) -> None:
     # navigator.languages (the full list) AND the realm Intl default locale (the
     # primary tag it extracts) - so Intl.DateTimeFormat / NumberFormat /
     # toLocaleString follow the locale, not just the Accept-Language header. Seed
-    # it with the full Accept-Language list so navigator.languages stays the
-    # desktop-default 2 elements (["fr-FR","fr"]); the C++ DidSet takes "fr-FR"
+    # it with the full Accept-Language list; the C++ DidSet takes the primary tag
     # for Intl. Mirrors juggler.timezone.override; the SOLE source of truth.
+    #
+    # A sentence here used to promise this keeps navigator.languages at 'the
+    # desktop-default 2 elements'. THAT IS WRONG. It was written when
+    # _accept_language() still returned 2 tags for every non-English locale,
+    # which was itself the defect corrected on 2026-08-19. Firefox DERIVES
+    # navigator.languages from this list, so the count is whatever the list
+    # holds, and looking like retail means matching the list, not a number.
+    #
+    # Measured 2026-08-19 against a signed retail 151.0 (judge151-frozen, the
+    # updater frozen) handed the same intl.accept_languages, same page served
+    # from 127.0.0.1, and read on the product path (a context WITH locale=):
+    #   retail it-IT  navigator.languages  it-IT, it, en-US, en   -> FOUR
+    #   ours   it-IT  navigator.languages  identical
+    #   retail it-IT  Accept-Language      it-IT,it;q=0.9,en-US;q=0.8,en;q=0.7
+    #   ours   it-IT  Accept-Language      identical
+    #
+    # en-US is the single locale where 2 and 4 coincide (the table has no 'en'
+    # row to append), which is why an en-US-only control kept the old sentence
+    # looking true for as long as it did.
     prefs["juggler.locale.override"]   = _accept_language(locale)
 
 

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -29,6 +29,7 @@ from invisible_core._geo import (
     _proxy_is_set,
     discover_egress_ip,
     ip_to_locale,
+    ip_to_coordinates,
     ip_to_timezone,
     prepare_session_geo,
     resolve_session_timezone,
@@ -213,6 +214,70 @@ def test_ip_to_timezone_invalid_iana_raises(monkeypatch):
     _install_fake_maxminddb(monkeypatch, {"location": {"time_zone": "Not/AZone"}})
     with pytest.raises(GeoTimezoneError):
         ip_to_timezone("198.51.100.4", "x.mmdb")
+
+
+# ──────────────────────────────────────────────────────────────────────
+#  ip_to_coordinates - stesso record del fuso, stesse mutazioni
+# ──────────────────────────────────────────────────────────────────────
+#
+# ⛔ Questa funzione e' arrivata SENZA test e SENZA consumatore: il core
+# dichiara la posizione, ma il 2026-08-23 nessun modulo la legge e nessuna pref
+# la porta al motore (voce 18 di `72-next-steps.md`). I test qui sotto coprono
+# il pezzo che esiste; il consumatore e' un'altra cosa e va scritto a parte.
+@pytest.mark.unit
+def test_ip_to_coordinates_reads_the_same_record_as_the_timezone(monkeypatch):
+    _install_fake_maxminddb(
+        monkeypatch,
+        {"location": {"time_zone": "Europe/Rome", "latitude": 41.9, "longitude": 12.5}},
+    )
+    assert ip_to_coordinates("198.51.100.4", "x.mmdb") == (41.9, 12.5)
+
+
+@pytest.mark.unit
+def test_ip_to_coordinates_returns_floats_not_whatever_the_database_stored(monkeypatch):
+    """Il database puo' portare interi: chi legge si aspetta due float."""
+    _install_fake_maxminddb(monkeypatch, {"location": {"latitude": 41, "longitude": 12}})
+    lat, lon = ip_to_coordinates("198.51.100.4", "x.mmdb")
+    assert isinstance(lat, float) and isinstance(lon, float)
+    assert (lat, lon) == (41.0, 12.0)
+
+
+@pytest.mark.unit
+def test_ip_to_coordinates_ip_absent_raises(monkeypatch):
+    _install_fake_maxminddb(monkeypatch, None)
+    with pytest.raises(GeoTimezoneError):
+        ip_to_coordinates("198.51.100.4", "x.mmdb")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "location",
+    [
+        {},
+        {"latitude": 41.9},                      # meta' record e' assenza
+        {"longitude": 12.5},
+        {"time_zone": "Europe/Rome"},            # il fuso c'e', la posizione no
+    ],
+)
+def test_ip_to_coordinates_incomplete_record_raises(monkeypatch, location):
+    """⛔ Non si inventa un ripiego: senza dichiarazione si rifiuta (regola 7)."""
+    _install_fake_maxminddb(monkeypatch, {"location": location})
+    with pytest.raises(GeoTimezoneError):
+        ip_to_coordinates("198.51.100.4", "x.mmdb")
+
+
+@pytest.mark.unit
+def test_a_session_without_coordinates_still_resolves_its_timezone(monkeypatch):
+    """La differenza VOLUTA fra i due: il fuso e' fatale, la posizione no.
+
+    Un fuso sbagliato dietro un proxy e' la trappola `tz_mismatch`; una
+    posizione assente e' solo un browser a cui nessuno ha chiesto dove sia.
+    """
+    _install_fake_maxminddb(monkeypatch, {"location": {"time_zone": "Europe/Rome"}})
+    geo = prepare_session_geo("Europe/Rome", None)
+    assert geo.timezone == "Europe/Rome"
+    assert geo.latitude is None and geo.longitude is None
+
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -33,7 +33,15 @@ def test_build_launch_plan_writes_userjs_env_and_argv(tmp_path, monkeypatch):
     plan = build_launch_plan(42, profile_dir=pdir, timezone="auto", locale="auto")
 
     assert plan.binary == "/fake/firefox"
-    assert plan.argv == ["/fake/firefox", "-no-remote", "-profile", str(pdir), "about:blank"]
+    # ⛔ SENZA URL IN CODA, ed e' la classe che conta, non la stringa: un URL
+    # sulla riga di comando ha la precedenza sulla pagina d'avvio, quindi il
+    # default "about:blank" che stava qui sopprimeva about:home a prescindere
+    # dalle prefs. Tolto il 2026-08-20 col revert del newtab.
+    assert plan.argv == ["/fake/firefox", "-no-remote", "-profile", str(pdir)]
+    # E chi ne vuole uno lo passa: il parametro e' ancora li'.
+    esplicito = build_launch_plan(42, profile_dir=pdir, timezone="auto",
+                                  locale="auto", url="https://example.invalid/")
+    assert esplicito.argv[-1] == "https://example.invalid/"
     text = (pdir / "user.js").read_text(encoding="utf-8")
     assert 'user_pref("zoom.stealth.screen.dpr", "1.25");' in text            # float -> string
     assert 'user_pref("toolkit.startup.max_resumed_crashes", -1);' in text    # no Safe Mode prompt

--- a/tests/test_prefs.py
+++ b/tests/test_prefs.py
@@ -84,14 +84,59 @@ def test_accept_language_with_region():
 
 @pytest.mark.unit
 def test_accept_language_no_region():
-    # AL2
-    assert _accept_language("fr") == "fr"
+    """AL2. Una lingua senza regione NON resta un tag solo.
+
+    ⛔ Questo test asseriva `_accept_language("fr") == "fr"` e codificava il
+    difetto corretto il 2026-08-19, non il comportamento di Firefox. Il valore
+    atteso qui sotto e' DERIVATO dalla tabella del motore, non da cio' che il
+    nostro codice restituisce - altrimenti il test non asserirebbe niente:
+
+        intl/locale/rust/locale_service_glue/src/lib.rs
+          "fr" => "fr, fr-FR",          <- la riga della tabella
+          add_en_us resta true          <- quindi in coda va ", en-US, en"
+
+    Nota che il primo tag e' la lingua NUDA e non `fr-FR`: e' la tabella a
+    volerlo, ed e' la ragione per cui una regione richiesta puo' non comparire
+    per prima.
+    """
+    assert _accept_language("fr") == "fr, fr-FR, en-US, en"
+
+
+@pytest.mark.unit
+def test_accept_language_no_region_when_the_table_has_no_row():
+    """AL2-bis. Il ramo `_` della tabella, che e' quello di quasi tutte le lingue.
+
+    Senza riga dedicata e senza regione, il motore restituisce la lingua e basta
+    (`lang.as_str()`), e poi aggiunge en-US. `ja` e' la riga di tabella che vale
+    esattamente "ja", quindi prova entrambe le strade allo stesso esito.
+    """
+    assert _accept_language("ja") == "ja, en-US, en"
 
 
 @pytest.mark.unit
 def test_accept_language_underscore_normalized():
-    # AL3
-    assert _accept_language("pt_BR") == "pt-BR, pt"
+    """AL3. Underscore normalizzato, e la coda en-US che mancava.
+
+    `pt` non ha riga in tabella, quindi cade nel ramo `_` con regione presente:
+    `format!("{lang}-{region}, {lang}")` -> "pt-BR, pt", piu' ", en-US, en".
+    """
+    assert _accept_language("pt_BR") == "pt-BR, pt, en-US, en"
+
+
+@pytest.mark.unit
+def test_accept_language_english_does_not_append_itself():
+    """AL3-bis. Il ramo che NON aggiunge en-US, e che nasconde gli altri sbagli.
+
+    Per `en` il motore mette `add_en_us = false`. E' l'unico locale su cui la
+    forma vecchia a due voci coincideva con quella giusta, ed e' per questo che
+    un controllo fatto solo su en-US ha lasciato passare il difetto per mesi.
+    Le altre due righe provano i due rami regionali espliciti.
+    """
+    assert _accept_language("en-US") == "en-US, en"
+    assert _accept_language("en-GB") == "en-GB, en"
+    assert _accept_language("en-CA") == "en-CA, en-US, en"
+    # E un caso NON inglese che pure rifiuta la coda: "sl" => add_en_us = false.
+    assert _accept_language("sl") == "sl, en-GB, en"
 
 
 @pytest.mark.unit
@@ -109,10 +154,18 @@ def test_accept_language_header_uses_the_q_values_firefox_actually_sends():
     `header.startswith(locale)` would have passed on the wrong value, which is
     how the wrong value survived to begin with.
     """
+    # I valori sono DERIVATI da netwerk/base/rust-helper/src/lib.rs
+    # (rust_prepare_accept_languages): il primo token non porta q, il token n
+    # porta q = max(10 - n, 1)/10, cioe' 0.9, 0.8, 0.7 ... e mai sotto 0.1.
+    # La lista di partenza e' quella della tabella dei locali, quindi le code
+    # ", en-US, en" compaiono anche qui.
     assert _accept_language_header("en-US") == "en-US,en;q=0.9"
-    assert _accept_language_header("pt_BR") == "pt-BR,pt;q=0.9"
-    # No region means one tag, and a single tag carries no q at all.
-    assert _accept_language_header("fr") == "fr"
+    assert _accept_language_header("pt_BR") == "pt-BR,pt;q=0.9,en-US;q=0.8,en;q=0.7"
+    # ⛔ Questa riga diceva `== "fr"` con il commento "senza regione un tag solo,
+    # e un tag solo non porta q". Era falsa due volte: la tabella da' a "fr" DUE
+    # voci piu' la coda inglese, quindi i token sono quattro e tre portano q.
+    assert _accept_language_header("fr") == "fr,fr-FR;q=0.9,en-US;q=0.8,en;q=0.7"
+    assert _accept_language_header("it-IT") == "it-IT,it;q=0.9,en-US;q=0.8,en;q=0.7"
     assert ";q=0.5" not in _accept_language_header("it-IT")
 
 
@@ -313,10 +366,16 @@ def test_locale_en_us_accept_languages():
 
 @pytest.mark.unit
 def test_locale_underscore_form_normalized():
-    # LC2
+    """LC2. L'underscore diventa trattino, e la lista porta la coda inglese.
+
+    `de` non ha riga nella tabella del motore, quindi cade nel ramo `_` con la
+    regione: "de-DE, de", piu' ", en-US, en" perche' add_en_us resta true.
+    Le due prefs di locale restano il TAG richiesto, non la lista: sono due
+    cose diverse e vanno asserite separatamente.
+    """
     p = generate_profile(seed=42)
     prefs = translate_profile_to_prefs(p, locale="de_DE")
-    assert prefs["intl.accept_languages"] == "de-DE, de"
+    assert prefs["intl.accept_languages"] == "de-DE, de, en-US, en"
     assert prefs["general.useragent.locale"] == "de-DE"
     assert prefs["intl.locale.requested"] == "de-DE"
 
@@ -568,9 +627,19 @@ def test_the_apis_a_real_firefox_has_are_not_switched_off():
     prefs = translate_profile_to_prefs(generate_profile(42))
     assert prefs["geo.enabled"] is True
     assert prefs["dom.push.enabled"] is True
-    # The network goal the False came from is kept by these two, so a future
-    # reader does not have to choose between the API and the quiet startup.
-    assert prefs["dom.push.connection.enabled"] is False
+    # ⛔ E `dom.push.connection.enabled` NON e' piu' dichiarata affatto. Questa
+    # riga la pretendeva a False, con il commento "l'obiettivo di rete da cui
+    # veniva il False e' tenuto da queste due": era vero fino al 2026-08-19,
+    # quando il proprietario ha deciso che le prefs che sopprimevano traffico
+    # fatto dal retail si TOLGONO invece di impostarle al valore del retail -
+    # togliere eredita il default di Gecko, che e' per definizione quello del
+    # retail, mentre impostare lascia un valore nostro che diverge il giorno in
+    # cui upstream cambia idea.
+    #
+    # Asserita come ASSENZA, nella stessa forma della riga su
+    # permissions.default.geo qui sotto, cosi' che rimetterla richieda di
+    # cancellare un test che spiega perche' non c'e'.
+    assert "dom.push.connection.enabled" not in prefs
     # And NOT permissions.default.geo. It was set to 2 (deny) to keep the
     # network quiet, and `navigator.permissions.query({name:"geolocation"})`
     # then answered `denied` where stock answers `prompt` - the only divergence

--- a/tests/test_prefs_sections.py
+++ b/tests/test_prefs_sections.py
@@ -144,12 +144,54 @@ def test_the_locale_defaults_to_en_US_and_normalises_underscores():
 
 
 def test_the_locale_override_carries_the_whole_accept_language_list():
-    """navigator.languages must stay the desktop-default two elements; the C++
-    DidSet takes the primary tag out of this for Intl."""
+    """L'override porta la LISTA INTERA, ed e' la stessa di intl.accept_languages.
+
+    ⛔ Questo test asseriva `.startswith("fr-FR")` e la docstring prometteva
+    "navigator.languages resta i due elementi predefiniti del desktop". Erano
+    tutte e due sbagliate, e per la stessa ragione corretta il 2026-08-19: la
+    tabella del motore mappa la lingua `fr` su "fr, fr-FR", cioe' mette per
+    primo il tag NUDO, e poi aggiunge ", en-US, en". Chiedere `fr-FR` non
+    produce una lista che comincia per `fr-FR`.
+
+    L'invariante vera, e l'unica che questo test deve difendere, e' che
+    l'override e la pref siano LA STESSA STRINGA: sono due nomi per un valore
+    solo, e il giorno in cui divergono navigator.languages e l'header dicono
+    cose diverse.
+    """
     prefs = {}
     P._apply_locale(prefs, "fr-FR")
     assert prefs["juggler.locale.override"] == prefs["intl.accept_languages"]
-    assert prefs["juggler.locale.override"].startswith("fr-FR")
+    assert prefs["juggler.locale.override"] == "fr, fr-FR, en-US, en"
+    # E il tag richiesto resta intero nelle prefs che portano il LOCALE, che
+    # sono un'altra cosa dalla lista delle lingue accettate.
+    assert prefs["intl.locale.requested"] == "fr-FR"
+    assert prefs["general.useragent.locale"] == "fr-FR"
+
+
+@pytest.mark.unit
+def test_the_primary_tag_of_the_list_is_not_always_the_requested_locale():
+    """⛔ La conseguenza che nessuno aveva scritto, isolata qui apposta.
+
+    `BrowsingContext`'s DidSet estrae il TAG PRIMARIO dell'override per fissare
+    il locale predefinito di Intl. Con la tabella vera quel tag NON coincide
+    sempre con il locale richiesto:
+
+        richiesto it-IT -> lista "it-IT, it, en-US, en" -> primario it-IT   uguale
+        richiesto fr-FR -> lista "fr, fr-FR, en-US, en" -> primario fr      DIVERSO
+
+    Questo test non dice che sia un difetto: dice che il caso ESISTE e lo
+    inchioda, perche' finora nessuna riga del progetto lo nominava. Se una
+    misura contro il retail dimostrera' che Intl deve restare sul tag
+    richiesto, il rimedio andra' nel C++ o in _apply_locale, e questo test
+    sara' il posto in cui la decisione si legge.
+    """
+    it, fr = {}, {}
+    P._apply_locale(it, "it-IT")
+    P._apply_locale(fr, "fr-FR")
+    primario = lambda p: p["juggler.locale.override"].split(",")[0].strip()
+    assert primario(it) == "it-IT" == it["intl.locale.requested"]
+    assert primario(fr) == "fr"
+    assert primario(fr) != fr["intl.locale.requested"]
 
 
 def test_no_timezone_writes_no_timezone_pref():


### PR DESCRIPTION
Tre cose che erano rimaste fuori dai commit.

Il revert del newtab arriva anche qui: browser.startup.page e le cinque prefs newtab escono, e l'url di build_launch_plan smette di valere about:blank, perche' un URL sulla riga di comando ha la precedenza sulla pagina d'avvio ed era la seconda meta' del revert.

Le tre chiavi API non sono piu' incise nel binario a tempo di compilazione: le dichiara il core e il motore rifiuta se mancano, senza ripiegare su una costante.

E ip_to_coordinates legge la posizione dallo stesso record dell'IP di uscita da cui esce gia' il fuso, cosi' posizione, fuso e lingua non possono contraddirsi. Arrivava senza test, adesso ne ha sei con le mutazioni provate una per una. Il consumatore non c'e' ancora e questo e' scritto, non sottinteso.
