### PR TITLE
macOS non piu' supportato, e la scoperta dell'IP si faceva due volte

### DIFF
--- a/src/invisible_core/_capacita.py
+++ b/src/invisible_core/_capacita.py
@@ -1,0 +1,345 @@
+"""Cosa sa fare DAVVERO l'uscita di questa sessione, misurato prima del lancio.
+
+⛔ QUESTO E' PRODOTTO, NON APPARATO DI MISURA, e la differenza si vede in una
+riga: cio' che questo modulo risponde DECIDE come il browser viene configurato.
+Nasce nel banco (`tests/lib/capacita_uscita.py`, 2026-08-25) e ci e' rimasto un
+giorno; adesso quel file e' un rimando a questo, perche' un fatto calcolato in
+due posti diverge.
+
+**La regola che il proprietario ha dettato il 2026-08-25, e che semplifica
+tutto:** cio' che si rileva PRIMA di avviare il browser e' la verita' della
+sessione, ed e' assoluta per la sua durata. Non si ricontrolla, non si insegue
+la deriva, non interessa se il proxy resti appiccicoso. Si misura una volta e si
+configura di conseguenza.
+
+⛔ LE CAPACITA' SONO UNA PROPRIETA' DEL GATEWAY, NON DELLA SESSIONE, ed e' cio'
+che rende praticabile sondarle. Misurato il 2026-08-25 su 500 sessioni: 95 peer
+vivi su un provider rispondono tutti `rep=7`, 100 su 100 su un altro, e i due
+gateway dello stesso account condividono 71 indirizzi su 71 dando risposte
+DIVERSE. Cambiare peer non cambia la risposta; cambiare gateway si'. Quindi si
+sonda una volta per endpoint e si riusa, invece di pagare secondi a ogni lancio.
+Costo misurato: 4-19 secondi, una volta ogni 24 ore per gateway.
+
+⛔ E L'ASSENZA DI PROVA CADE SEMPRE DALLA PARTE PRUDENTE. Se la sonda non
+risponde, o risponde in modo ambiguo, la configurazione e' quella di sempre.
+Una capacita' si sfrutta solo quando e' DIMOSTRATA, perche' sbagliare in
+quella direzione costa il messaggio peggiore che un rilevatore possa scrivere:
+misurato leggendo il codice di un rilevatore vero, un browser che non emette
+candidati si prende "Javascript is manipulated" invece di "VPN detected"
+(`docs_research/scrapfly-re/00-WEBRTC-LEAK.md`).
+
+Nessuna funzione qui stampa una credenziale.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import socket
+import struct
+import time
+from typing import Any, Dict, Optional
+from urllib.parse import urlparse
+
+#: Dove si ricorda cio' che si e' misurato. Fuori dall'albero git, come gli
+#: altri segreti: la chiave contiene l'hostname del provider.
+CACHE = os.path.join(os.environ.get("TEMP", "/tmp"), "capacita_uscita.json")
+
+#: Quanto vale una misura prima di rifarla. Le capacita' di un gateway cambiano
+#: quando il fornitore cambia infrastruttura, non di ora in ora.
+VALIDITA_S = 24 * 3600
+
+_REP = {0: "ok", 1: "guasto generale", 2: "non consentito", 3: "rete irraggiungibile",
+        4: "host irraggiungibile", 5: "conn rifiutata", 6: "ttl scaduto",
+        7: "comando non supportato", 8: "tipo indirizzo non supportato"}
+
+
+# --------------------------------------------------------------------------
+# I mattoni: una domanda ciascuno, nessuno interpreta.
+# --------------------------------------------------------------------------
+
+def _saluta_socks5(s, utente: str, segreto: str) -> Optional[str]:
+    s.sendall(b"\x05\x01\x02")
+    r = s.recv(2)
+    if len(r) != 2 or r[0] != 5:
+        return "saluto non SOCKS5"
+    if r[1] == 2:
+        u, p = utente.encode(), segreto.encode()
+        s.sendall(b"\x01" + bytes([len(u)]) + u + bytes([len(p)]) + p)
+        a = s.recv(2)
+        if len(a) != 2 or a[1] != 0:
+            return "autenticazione rifiutata"
+    elif r[1] == 0xFF:
+        return "nessun metodo di autenticazione accettabile"
+    return None
+
+
+def _connect_socks5(s, host: str, porta: int) -> Optional[int]:
+    h = host.encode()
+    s.sendall(b"\x05\x01\x00\x03" + bytes([len(h)]) + h + struct.pack("!H", porta))
+    r = s.recv(10)
+    return r[1] if len(r) >= 2 and r[0] == 5 else None
+
+
+def uscita_tcp(proxy: Dict[str, str], timeout: float = 25) -> Optional[str]:
+    """L'indirizzo da cui esce il TCP, letto in chiaro su una connessione sola."""
+    u = urlparse(proxy["server"])
+    try:
+        s = socket.create_connection((u.hostname, u.port), timeout=timeout)
+        s.settimeout(timeout)
+        # ⛔ Uno schema `https` significa TLS verso il PROXY, prima di
+        # qualunque richiesta. La prima stesura parlava HTTP in chiaro a una
+        # porta TLS e tornava `None`, che il riassunto mostrava come "sticky
+        # non determinato": un difetto dello strumento travestito da proprieta'
+        # dell'endpoint. Il certificato si verifica sul serio, perche' e' quello
+        # che distingue l'host giusto da uno che gli somiglia.
+        if u.scheme == "https":
+            import ssl
+            s = ssl.create_default_context().wrap_socket(s, server_hostname=u.hostname)
+        try:
+            if u.scheme.startswith("socks"):
+                if _saluta_socks5(s, proxy.get("username", ""), proxy.get("password", "")):
+                    return None
+                if _connect_socks5(s, "api.ipify.org", 80) != 0:
+                    return None
+                s.sendall(b"GET / HTTP/1.1\r\nHost: api.ipify.org\r\n"
+                          b"Connection: close\r\nUser-Agent: curl/8\r\n\r\n")
+            else:
+                import base64
+                cred = base64.b64encode(
+                    ("%s:%s" % (proxy.get("username", ""),
+                                proxy.get("password", ""))).encode()).decode()
+                s.sendall(("GET http://api.ipify.org/ HTTP/1.1\r\n"
+                           "Host: api.ipify.org\r\nProxy-Authorization: Basic %s\r\n"
+                           "Connection: close\r\nUser-Agent: curl/8\r\n\r\n" % cred).encode())
+            dati = b""
+            while len(dati) < 4096:
+                p = s.recv(4096)
+                if not p:
+                    break
+                dati += p
+            m = re.search(rb"\b(?:\d{1,3}\.){3}\d{1,3}\b", dati.split(b"\r\n\r\n")[-1])
+            return m.group(0).decode() if m else None
+        finally:
+            s.close()
+    except OSError:
+        return None
+
+
+def udp_associate(proxy: Dict[str, str], timeout: float = 25):
+    """`(supportato, spiegazione)`. Solo SOCKS5: in HTTP il comando non esiste."""
+    u = urlparse(proxy["server"])
+    if not u.scheme.startswith("socks"):
+        return False, "schema %s: SOCKS UDP ASSOCIATE non esiste nel protocollo" % u.scheme
+    try:
+        s = socket.create_connection((u.hostname, u.port), timeout=timeout)
+        s.settimeout(timeout)
+        try:
+            e = _saluta_socks5(s, proxy.get("username", ""), proxy.get("password", ""))
+            if e:
+                return False, e
+            s.sendall(b"\x05\x03\x00\x01" + b"\x00" * 4 + b"\x00\x00")
+            r = s.recv(4)
+            if not r:
+                return False, "il gateway ha chiuso senza rispondere"
+            if len(r) < 4 or r[0] != 5:
+                return False, "risposta non interpretabile"
+            if r[1] != 0:
+                return False, "rep=%d %s" % (r[1], _REP.get(r[1], "?"))
+            atyp = r[3]
+            ind = (socket.inet_ntoa(s.recv(4)) if atyp == 1 else
+                   s.recv(s.recv(1)[0]).decode() if atyp == 3 else
+                   socket.inet_ntop(socket.AF_INET6, s.recv(16)))
+            porta = struct.unpack("!H", s.recv(2))[0]
+            if ind in ("0.0.0.0", "::"):
+                ind = u.hostname
+            return True, "%s:%d" % (ind, porta)
+        finally:
+            s.close()
+    except OSError as ex:
+        return False, "errore %s" % type(ex).__name__
+
+
+def uscita_udp(proxy: Dict[str, str], timeout: float = 12) -> Optional[str]:
+    """L'indirizzo da cui esce l'UDP, chiesto a STUN. `None` se UDP non passa.
+
+    E' la meta' che quasi nessuno misura, e senza la quale "il proxy porta UDP"
+    non basta: se questo indirizzo non e' lo stesso del TCP, usarlo per WebRTC
+    produce due indirizzi in una sessione, cioe' il disaccordo che i rilevatori
+    cercano.
+    """
+    ok, dove = udp_associate(proxy)
+    if not ok:
+        return None
+    host, _, porta = dove.rpartition(":")
+    u = urlparse(proxy["server"])
+    try:
+        ctrl = socket.create_connection((u.hostname, u.port), timeout=timeout)
+        ctrl.settimeout(timeout)
+        if _saluta_socks5(ctrl, proxy.get("username", ""), proxy.get("password", "")):
+            ctrl.close()
+            return None
+        ctrl.sendall(b"\x05\x03\x00\x01" + b"\x00" * 4 + b"\x00\x00")
+        ctrl.recv(10)
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.settimeout(timeout)
+        try:
+            h = b"stun.l.google.com"
+            testa = b"\x00\x00\x00\x03" + bytes([len(h)]) + h + struct.pack("!H", 19302)
+            s.sendto(testa + b"\x00\x01\x00\x00\x21\x12\xa4\x42" + os.urandom(12),
+                     (host, int(porta)))
+            d, _ = s.recvfrom(2048)
+            if len(d) < 10 or d[2] != 0:
+                return None
+            atyp, i = d[3], 4
+            i += 4 if atyp == 1 else (1 + d[4] if atyp == 3 else 16)
+            c = d[i + 2:]
+            if len(c) < 20 or c[0:2] != b"\x01\x01":
+                return None
+            j, fine = 20, 20 + struct.unpack("!H", c[2:4])[0]
+            while j + 4 <= min(fine, len(c)):
+                t, ln = struct.unpack("!HH", c[j:j + 4])
+                v = c[j + 4:j + 4 + ln]
+                if t == 0x0020 and len(v) >= 8:
+                    ip = bytes(a ^ b for a, b in zip(v[4:8], b"\x21\x12\xa4\x42"))
+                    return socket.inet_ntoa(ip)
+                j += 4 + ln + ((4 - ln % 4) % 4)
+            return None
+        finally:
+            s.close()
+            ctrl.close()
+    except OSError:
+        return None
+
+
+def ha_ipv6(proxy: Dict[str, str], timeout: float = 20) -> Optional[bool]:
+    """`True`/`False`, oppure `None` se la domanda non e' stata risolta.
+
+    ⛔ Il `None` NON e' un `False`: un fallimento di rete e una uscita senza
+    IPv6 sono cose diverse, e appiattirle farebbe spegnere IPv6 per un timeout.
+    """
+    u = urlparse(proxy["server"])
+    if not u.scheme.startswith("socks"):
+        return None
+    try:
+        s = socket.create_connection((u.hostname, u.port), timeout=timeout)
+        s.settimeout(timeout)
+        try:
+            if _saluta_socks5(s, proxy.get("username", ""), proxy.get("password", "")):
+                return None
+            if _connect_socks5(s, "api6.ipify.org", 80) != 0:
+                return False
+            s.sendall(b"GET / HTTP/1.1\r\nHost: api6.ipify.org\r\n"
+                      b"Connection: close\r\nUser-Agent: curl/8\r\n\r\n")
+            dati = b""
+            while len(dati) < 4096:
+                p = s.recv(4096)
+                if not p:
+                    break
+                dati += p
+            corpo = dati.split(b"\r\n\r\n")[-1]
+            return b":" in corpo and len(corpo.strip()) > 2
+        finally:
+            s.close()
+    except OSError:
+        return None
+
+
+def e_sticky(proxy: Dict[str, str], giri: int = 6):
+    """`(sticky, indirizzi)`. Sei letture con la STESSA credenziale.
+
+    Sei e non due: due estrazioni uguali di fila da un'urna non dimostrano che
+    l'urna abbia una pallina sola, ed e' un errore che questo progetto ha gia'
+    fatto e registrato.
+    """
+    visti = [uscita_tcp(proxy) for _ in range(giri)]
+    buoni = [x for x in visti if x]
+    distinti = sorted(set(buoni))
+    if not buoni:
+        return None, []
+    return len(distinti) == 1, distinti
+
+
+# --------------------------------------------------------------------------
+# Il verdetto, e la memoria
+# --------------------------------------------------------------------------
+
+def _chiave(proxy: Dict[str, str]) -> str:
+    u = urlparse(proxy["server"])
+    return "%s://%s:%s" % (u.scheme, u.hostname, u.port)
+
+
+def misura(proxy: Dict[str, str],
+           *, uscita_tcp_nota: Optional[str] = None) -> Dict[str, Any]:
+    """Tutto quello che si puo' sapere di un'uscita senza lanciare un browser.
+
+    ``uscita_tcp_nota`` evita di rimisurare cio' che il chiamante ha gia'.
+    ``prepare_session_geo`` scopre l'IP di uscita per il fuso e la lingua, con
+    un giro attraverso il proxy: rifarlo qui sarebbe lo stesso fatto calcolato
+    in due punti, e un giro in piu' verso un endpoint di echo, che e' traffico
+    non-di-browser sulla stessa uscita.
+
+    ⛔ LA STICKINESS NON E' PIU' QUI, ed e' una decisione del proprietario del
+    2026-08-25: *"cosa succede se i proxy sono sticky o no non ti interessa, per
+    te la verita' e' quella che rilevi prima di avviare ed e' assoluta per la
+    sessione"*. Toglierla costa zero e vale due volte:
+
+    * era **sei giri di rete su otto** del costo di questa sonda;
+    * e **mentiva**. Diceva `sticky = si` per tutti e quattro i fornitori, mentre
+      lo stesso endpoint era stato misurato ruotare **8 volte in 25 minuti**
+      (`27-retail-network-parity.md` sezione 17). Sei letture consecutive durano
+      pochi secondi, la rotazione avviene su una scala di minuti: quel campo non
+      poteva vedere il fenomeno da cui prendeva il nome.
+
+    ``e_sticky`` resta disponibile per chi voglia MISURARE la rotazione con una
+    finestra adeguata, ma non entra piu' in nessuna decisione del prodotto.
+    """
+    ip_tcp = uscita_tcp_nota or uscita_tcp(proxy)
+    ok_udp, perche = udp_associate(proxy)
+    ip_udp = uscita_udp(proxy) if ok_udp else None
+    return {
+        "endpoint": _chiave(proxy),
+        "schema": urlparse(proxy["server"]).scheme,
+        "uscita_tcp": ip_tcp,
+        "udp": ok_udp,
+        "udp_perche": perche,
+        "uscita_udp": ip_udp,
+        # ⛔ la riga che decide se UDP sia USABILE, non solo CONCESSO.
+        # Misurato: un gateway concede l'UDP ASSOCIATE e restituisce un relay,
+        # e attraverso quel relay lo STUN non risponde. Concesso non e' usabile.
+        "udp_coerente": (bool(ip_udp) and ip_udp == ip_tcp) if ok_udp else None,
+        "ipv6": ha_ipv6(proxy),
+        "quando": int(time.time()),
+    }
+
+
+def capacita(proxy: Dict[str, str], *, rimisura: bool = False,
+             uscita_tcp_nota: Optional[str] = None) -> Dict[str, Any]:
+    """La misura, dalla memoria se e' recente. Le capacita' sono del gateway."""
+    chiave = _chiave(proxy)
+    memoria = {}
+    try:
+        with open(CACHE, encoding="utf-8") as f:
+            memoria = json.load(f)
+    except (OSError, ValueError):
+        pass
+    voce = memoria.get(chiave)
+    if voce and not rimisura and (time.time() - voce.get("quando", 0)) < VALIDITA_S:
+        voce["da_memoria"] = True
+        return voce
+    voce = misura(proxy, uscita_tcp_nota=uscita_tcp_nota)
+    memoria[chiave] = voce
+    try:
+        with open(CACHE, "w", encoding="utf-8") as f:
+            json.dump(memoria, f, indent=1)
+    except OSError:
+        pass
+    voce["da_memoria"] = False
+    return voce
+
+
+def riassumi(c: Dict[str, Any]) -> str:
+    def _s(v):
+        return "si" if v is True else ("no" if v is False else "non determinato")
+    return ("%-46s udp=%-16s coerente=%-16s ipv6=%s"
+            % (c["endpoint"], _s(c["udp"]), _s(c["udp_coerente"]), _s(c["ipv6"])))

--- a/src/invisible_core/_geo.py
+++ b/src/invisible_core/_geo.py
@@ -310,7 +310,18 @@ def resolve_session_locale(egress_ip: Optional[str], proxy: Optional[Dict[str, s
     from .download import ensure_geoip_mmdb
 
     try:
-        ip = egress_ip if _proxy_is_set(proxy) else discover_egress_ip(None)
+        # ⛔ SI RIUSA CIO' CHE IL CHIAMANTE HA GIA': `prepare_session_geo` ha
+        # gia' pagato questo round-trip e adesso porta il risultato anche senza
+        # proxy. Si scopre solo se non c'e' niente da riusare - il caso di un
+        # fuso esplicito, in cui nessuno ha ancora chiesto niente alla rete.
+        #
+        # E la scoperta resta VIETATA dietro un proxy: se li' `egress_ip` manca,
+        # la scoperta e' fallita, e cadere sull'indirizzo diretto derivarebbe la
+        # lingua dal paese di CASA mentre il fuso dice quello del proxy. Meglio
+        # `en-US` di una contraddizione fra due campi.
+        ip = egress_ip
+        if ip is None and not _proxy_is_set(proxy):
+            ip = discover_egress_ip(None)
         if ip is None:
             _warn_locale_fallback(proxy, "no egress IP was resolved")
             return "en-US"
@@ -352,10 +363,19 @@ class SessionGeo(NamedTuple):
     """Geo facts resolved once per session from a single egress round-trip.
 
     ``timezone`` follows the precedence in the module docstring.
-    ``egress_ip`` is the proxy egress IP (the IP the *outside world* sees) when
-    a proxy is set, else ``None`` - it feeds the WebRTC srflx override, which is
-    only meaningful behind a proxy (a direct connection's real STUN already
-    reports the truthful public IP, so we leave it alone).
+
+    ⛔ ``egress_ip`` E' UN FATTO, NON UNA DECISIONE: l'indirizzo da cui questa
+    sessione esce davvero, scoperto una volta, con o senza proxy. Se poi quel
+    valore venga DICHIARATO al motore come srflx lo decide
+    :meth:`srflx_da_dichiarare`, e la risposta senza proxy e' no.
+
+    Fino al 2026-08-26 questo campo valeva ``None`` senza proxy, e il "no" era
+    espresso proprio da quel ``None``. Un campo solo per due significati:
+    l'effetto era che ``prepare_session_geo`` scopriva l'indirizzo per il fuso,
+    **lo buttava via**, e ``resolve_session_locale`` doveva riscoprirlo. Due
+    richieste identiche a un servizio esterno, dall'indirizzo vero, prima che il
+    browser esista - dove un utente vero ne fa zero. Il fatto adesso si porta,
+    e il "no" vive dove viveva gia' la decisione.
     """
 
     timezone: str
@@ -410,8 +430,15 @@ def _srflx_soppresso(proxy: Optional[Dict[str, str]],
     e candidato lato client e prova lato server coincidono per costruzione. E'
     quell'implicazione che un candidato dichiarato rompe.
 
-    Da qui la regola, che ha due rami e non uno:
+    Da qui la regola, che ha tre rami:
 
+    * **nessun proxy**: lo STUN vero risponde con l'indirizzo da cui si esce
+      davvero, quindi il srflx nasce gia' giusto e con la sua allocazione. Non
+      si dichiara niente. Fino al 2026-08-26 questo ramo non era scritto qui:
+      lo stesso esito usciva dal fatto che ``egress_ip`` valesse ``None`` senza
+      proxy, cioe' la decisione era codificata nell'ASSENZA di un fatto. Le due
+      cose sono ora separate, e questo ramo dice a voce cio' che prima si
+      otteneva per effetto collaterale.
     * **UDP dimostrato e coerente** (l'UDP esce dallo stesso indirizzo del TCP):
       il srflx vero nascera' gia' con l'indirizzo giusto. Non si dichiara niente:
       dichiarare aggiungerebbe un candidato senza allocazione corrispondente.
@@ -424,8 +451,10 @@ def _srflx_soppresso(proxy: Optional[Dict[str, str]],
     rete, timeout, un campo che non c'e' - si ricade sul ramo prudente. Una
     capacita' si sfrutta solo quando e' DIMOSTRATA.
     """
-    if not _proxy_is_set(proxy) or not egress_ip:
-        return False
+    if not egress_ip:
+        return False  # niente da dichiarare comunque: il ramo prudente
+    if not _proxy_is_set(proxy):
+        return True  # connessione diretta: il srflx vero e' gia' la verita'
     # ⛔ PRIMA DELLA SONDA, perche' se questo e' falso la sonda non serve.
     #
     # Che l'USCITA porti UDP coerente non basta: deve anche essere il BROWSER a
@@ -502,8 +531,12 @@ def prepare_session_geo(
         if ip is None:  # proxy set but discovery failed above
             raise egress_err or GeoTimezoneError("egress IP discovery failed")
         lat, lon = _coordinate(ip)
-        return SessionGeo(ip_to_timezone(ip, ensure_geoip_mmdb()), egress_ip, lat, lon,
-                          _srflx_soppresso(proxy, egress_ip))
+        # ⛔ SI PORTA `ip`, NON `egress_ip`. Dietro un proxy sono lo stesso
+        # valore; senza, `ip` e' il fatto che questo giro di rete ha appena
+        # pagato e `egress_ip` e' `None`. Portare il secondo significava
+        # buttare la scoperta e farla rifare a `resolve_session_locale`.
+        return SessionGeo(ip_to_timezone(ip, ensure_geoip_mmdb()), ip, lat, lon,
+                          _srflx_soppresso(proxy, ip))
     except Exception:
         if proxy_set:
             raise  # fail-early behind a proxy (timezone_mismatch trap)

--- a/src/invisible_core/_geo.py
+++ b/src/invisible_core/_geo.py
@@ -370,6 +370,68 @@ class SessionGeo(NamedTuple):
     #: sarebbe stato un cambiamento non retrocompatibile di un tipo esportato.
     latitude: Optional[float] = None
     longitude: Optional[float] = None
+    #: ⛔ UN INTERRUTTORE, E IL SUO DEFAULT E' QUELLO PRUDENTE.
+    #:
+    #: La prima stesura era un campo che portava l'INDIRIZZO da dichiarare, con
+    #: default ``None``. Sbagliato, e un test lo ha colto subito: ``SessionGeo``
+    #: si costruisce per posizione in sei punti fra codice e test, e tutti
+    #: quelli che non conoscevano il campo nuovo hanno smesso di dichiarare il
+    #: srflx **per distrazione**. Cioe' il default cadeva dal lato che porta al
+    #: messaggio peggiore che un rilevatore possa scrivere.
+    #:
+    #: Invertito: ``False`` significa "dichiara", che e' il comportamento di
+    #: sempre, e per spegnerlo bisogna dirlo. Vale ``True`` SOLO quando l'uscita
+    #: ha UDP dimostrato E coerente, perche' li' il srflx vero nasce gia' con
+    #: l'indirizzo giusto e dichiararne uno aggiungerebbe un candidato senza
+    #: allocazione corrispondente.
+    srflx_soppresso: bool = False
+
+    def srflx_da_dichiarare(self) -> Optional[str]:
+        """L'indirizzo che il motore deve annunciare come srflx, o ``None``.
+
+        ⛔ E' L'UNICO POSTO in cui questa domanda riceve risposta. I due
+        costruttori di env - ``launch.build_launch_env`` nel core e
+        ``_session.build_env`` nel wrapper - la chiamano, non la ricalcolano:
+        erano gia' due punti di atterraggio, e la stessa regola scritta due
+        volte avrebbe potuto divergere.
+        """
+        return None if self.srflx_soppresso else self.egress_ip
+
+
+def _srflx_soppresso(proxy: Optional[Dict[str, str]],
+                     egress_ip: Optional[str]) -> bool:
+    """Dichiarare un srflx sintetico, o lasciar passare quello vero?
+
+    Il criterio viene dal codice di un rilevatore vero, letto e non dedotto
+    (`docs_research/scrapfly-re/00-WEBRTC-LEAK.md`): la sua configurazione non
+    contiene nessuno STUN, solo TURN, e la username dell'allocazione e' lo
+    stesso identificativo che il POST di verifica manda al backend. Quindi in un
+    browser onesto **un srflx puo' venire soltanto da un'allocazione riuscita**,
+    e candidato lato client e prova lato server coincidono per costruzione. E'
+    quell'implicazione che un candidato dichiarato rompe.
+
+    Da qui la regola, che ha due rami e non uno:
+
+    * **UDP dimostrato e coerente** (l'UDP esce dallo stesso indirizzo del TCP):
+      il srflx vero nascera' gia' con l'indirizzo giusto. Non si dichiara niente:
+      dichiarare aggiungerebbe un candidato senza allocazione corrispondente.
+    * **tutto il resto**: si dichiara l'IP di uscita, che e' il comportamento di
+      sempre. Senza un srflx il rilevatore scrive *"Javascript is manipulated"*,
+      cioe' accusa il browser; con lui scrive *"VPN/PROXY detected"*, cioe'
+      accusa la rete. La differenza fra i due messaggi e' questa riga.
+
+    ⛔ E LA SONDA NON PUO' FAR FALLIRE UN LANCIO. Qualunque cosa vada storta -
+    rete, timeout, un campo che non c'e' - si ricade sul ramo prudente. Una
+    capacita' si sfrutta solo quando e' DIMOSTRATA.
+    """
+    if not _proxy_is_set(proxy) or not egress_ip:
+        return False
+    try:
+        from ._capacita import capacita
+        c = capacita(proxy, uscita_tcp_nota=egress_ip)
+    except Exception:  # noqa: BLE001
+        return False
+    return c.get("udp") is True and c.get("udp_coerente") is True
 
 
 def prepare_session_geo(
@@ -418,13 +480,15 @@ def prepare_session_geo(
 
     if tz and tz.lower() != "auto":
         lat, lon = _coordinate(egress_ip)
-        return SessionGeo(tz, egress_ip, lat, lon)  # explicit IANA wins
+        return SessionGeo(tz, egress_ip, lat, lon,
+                          _srflx_soppresso(proxy, egress_ip))  # explicit IANA wins
     try:
         ip = egress_ip if proxy_set else discover_egress_ip(None)
         if ip is None:  # proxy set but discovery failed above
             raise egress_err or GeoTimezoneError("egress IP discovery failed")
         lat, lon = _coordinate(ip)
-        return SessionGeo(ip_to_timezone(ip, ensure_geoip_mmdb()), egress_ip, lat, lon)
+        return SessionGeo(ip_to_timezone(ip, ensure_geoip_mmdb()), egress_ip, lat, lon,
+                          _srflx_soppresso(proxy, egress_ip))
     except Exception:
         if proxy_set:
             raise  # fail-early behind a proxy (timezone_mismatch trap)

--- a/src/invisible_core/_geo.py
+++ b/src/invisible_core/_geo.py
@@ -426,6 +426,21 @@ def _srflx_soppresso(proxy: Optional[Dict[str, str]],
     """
     if not _proxy_is_set(proxy) or not egress_ip:
         return False
+    # ⛔ PRIMA DELLA SONDA, perche' se questo e' falso la sonda non serve.
+    #
+    # Che l'USCITA porti UDP coerente non basta: deve anche essere il BROWSER a
+    # mandarci l'UDP. Con `network.proxy.socks_remote_udp` spenta l'UDP scavalca
+    # il proxy, quindi un srflx vero nascerebbe con l'indirizzo di CASA - e
+    # smettere di dichiarare, li', sarebbe una fuga vera invece di un rimedio.
+    #
+    # La prima stesura di questa funzione, il 2026-08-25, non lo controllava. Il
+    # ramo era irraggiungibile per fortuna (nessun fornitore ha UDP usabile) e
+    # non per costruzione, che e' esattamente la forma di difetto che questo
+    # progetto paga: una condizione la cui sicurezza dipende da un fatto che non
+    # verifica.
+    from ._proxy import INSTRADIAMO_UDP_NEL_SOCKS
+    if not INSTRADIAMO_UDP_NEL_SOCKS:
+        return False
     try:
         from ._capacita import capacita
         c = capacita(proxy, uscita_tcp_nota=egress_ip)

--- a/src/invisible_core/_headless.py
+++ b/src/invisible_core/_headless.py
@@ -168,16 +168,16 @@ def make_virtual_display():
     platform hides windows via the in-binary cloak pref instead.
 
     - Linux: a fresh ``Xvfb`` (the launcher start()s/stop()s it).
-    - Windows / macOS: ``None`` - the binary self-cloaks via ``cloak_prefs()``,
+    - Windows: ``None`` - the binary self-cloaks via ``cloak_prefs()``,
       injected by the launcher; nothing host-side needs spawning.
     """
     if sys.platform.startswith("linux"):
         return _LinuxVirtualDisplay()
-    if sys.platform in ("win32", "darwin"):
+    if sys.platform == "win32":
         return None
     raise RuntimeError(
-        f"invisible_playwright supports Windows, macOS and Linux "
-        f"(got {sys.platform!r})"
+        f"invisible_playwright supporta Windows e Linux "
+        f"(macOS non e' piu' supportato; got {sys.platform!r})"
     )
 
 

--- a/src/invisible_core/_proxy.py
+++ b/src/invisible_core/_proxy.py
@@ -243,6 +243,26 @@ def _configure_http_like(
     return None
 
 
+#: Il browser fa passare l'UDP DENTRO il tunnel SOCKS?
+#:
+#: ⛔ NO, e questa costante esiste perche' la risposta non e' ovvia e una
+#: decisione ne dipende. Il motore ha il codice per farlo
+#: (`netwerk/socket/nsSOCKSUDPIOLayer.{h,cpp}`, agganciato in `nsUDPSocket.cpp`)
+#: ma e' dietro `network.proxy.socks_remote_udp`, che non impostiamo. Senza,
+#: **l'UDP scavalca il proxy** e uno STUN raggiunto per quella via risponde con
+#: l'indirizzo VERO della macchina.
+#:
+#: Chi la legge: `_geo._srflx_soppresso`. Smettere di dichiarare un srflx ha
+#: senso solo se quello VERO nascera' con l'indirizzo giusto, e con l'UDP che
+#: scavalca il proxy nascerebbe con l'indirizzo di casa. Cioe' la condizione
+#: "l'uscita porta UDP coerente" NON basta: serve anche che il browser quell'UDP
+#: lo mandi di la'.
+#:
+#: Il giorno in cui si accende la pref, questa costante si sposta con lei - e
+#: sono lo stesso fatto scritto in un posto solo.
+INSTRADIAMO_UDP_NEL_SOCKS = False
+
+
 def _is_socks_scheme(server: str) -> bool:
     return server.lower().startswith(_SOCKS_SCHEMES)
 

--- a/src/invisible_core/_proxy.py
+++ b/src/invisible_core/_proxy.py
@@ -149,6 +149,21 @@ def configure_proxy(
     # con `RESOLVE_IGNORE_SOCKS_DNS`, che il cancello esenta per primo. Non e'
     # una deroga che aggiungiamo noi: e' quella che gia' regge il ramo SOCKS.
     prefs["zoom.stealth.dns.no_local_resolution"] = True
+
+    # ⛔ E L'UDP DI ICE ESCE LO STESSO, se il server e' scritto come
+    # INDIRIZZO NUMERICO invece che come nome. Il cancello DNS qui sopra non
+    # lo puo' fermare, perche' un letterale non passa dal resolver.
+    #
+    # Misurato il 2026-08-26 su tre fornitori e due schemi: con uno STUN
+    # numerico il motore riceve il MAPPED-ADDRESS con l'indirizzo VERO della
+    # macchina, mentre la pagina vede l'uscita del proxy perche' il candidato
+    # reale viene riscritto. Una fuga che nessun controllo lato pagina puo'
+    # vedere, e che vede solo chi gestisce lo STUN.
+    #
+    # Le due prefs stanno qui insieme apposta: dicono al motore la stessa
+    # cosa da due lati - dietro un proxy nulla esce per una strada che il
+    # proxy non copre - e una decisione sola le emette entrambe.
+    prefs["zoom.stealth.webrtc.no_direct_udp"] = True
     return risultato
 
 

--- a/src/invisible_core/_proxy.py
+++ b/src/invisible_core/_proxy.py
@@ -46,9 +46,120 @@ def configure_proxy(
     server = (proxy.get("server") or "").strip()
     if not server or server.lower() == "direct://":
         return None
-    if not _is_socks_scheme(server):
-        return _configure_http_like(proxy, prefs, server, delegates_auth)
 
+    # ⛔ QUI E' STATA PROVATA `network.dns.disableIPv6 = True` E TOLTA: E' INERTE
+    # DIETRO UN PROXY, e una patch che non sposta nessuna misura non e' una
+    # patch.
+    #
+    # L'idea era rendere il profilo IPv4-only per intero: i candidati WebRTC
+    # IPv6 li scartiamo gia' dietro proxy (l'srflx IPv6 non e' offuscato
+    # dall'mDNS e porterebbe l'indirizzo globale VERO), ma l'HTTP poteva ancora
+    # uscire in IPv6 - misurato il 2026-08-25 su un peer residenziale
+    # dual-stack: dichiaravamo `73.209.132.45` mentre la stessa pagina
+    # raggiungeva un servizio di echo su `2603:300a:92e:8600:...`.
+    #
+    # La pref pero' non cambia niente, e il controfattuale lo dimostra: applicata
+    # e RILETTA dal profilo del browser (`network.dns.disableIPv6 true`), l'echo
+    # continuava a uscire sullo stesso IPv6. La ragione e' `socks_remote_dns`:
+    # Firefox consegna al proxy il NOME, non un indirizzo, quindi e' il proxy a
+    # risolvere e a scegliere la famiglia. Il resolver di Firefox non viene
+    # nemmeno interpellato, e lo stesso vale per un proxy HTTP, dove il nome
+    # viaggia dentro la CONNECT.
+    #
+    # Conseguenza da sapere: **la famiglia di indirizzi dietro un proxy non la
+    # decidiamo noi.** Se il peer ha IPv6 e il sito e' dual-stack, usciamo in
+    # IPv6 mentre WebRTC annuncia un IPv4. Chiuderlo davvero vuol dire
+    # dichiarare ANCHE un srflx IPv6 con l'uscita IPv6 del proxy (scopribile:
+    # `api6.ipify.org` attraverso il proxy risponde), non spegnere IPv6 da
+    # questo lato.
+
+    if not _is_socks_scheme(server):
+        risultato = _configure_http_like(proxy, prefs, server, delegates_auth)
+    else:
+        risultato = _configure_socks(proxy, prefs, server)
+
+    # ⛔ QUANDO IL PROXY INCIAMPA, IL RIPIEGO DI FIREFOX E' USCIRE IN CHIARO.
+    #
+    # `network.proxy.allow_bypass` vale `true` di default - letto dall'header
+    # GENERATO della nostra build, `dist/include/mozilla/StaticPrefList_network.h`,
+    # non dallo yaml - e un canale che chiede `bypassProxy` salta
+    # `ResolveProxy()` del tutto (`netwerk/protocol/http/nsHttpChannel.cpp`, la
+    # guardia `!BypassProxy()`). Quel canale poi risolve il nome col resolver
+    # dell'utente, perche' senza `mProxyInfo` il DNS viene FORZATO con
+    # `RESOLVE_IGNORE_SOCKS_DNS` (`DnsAndConnectSocket.cpp`; il commento
+    # upstream lo dice: "force resolution despite global proxy-DNS
+    # configuration"). Non e' solo DNS: e' una connessione DIRETTA, con l'IP
+    # vero, e parte proprio nell'istante in cui il proxy sta gia' fallendo.
+    #
+    # Chi la usa: `services/settings/Utils.sys.mjs` (`fallbackOrReject`, su
+    # onerror/ontimeout/onabort) e `TelemetrySend.sys.mjs` (`retryRequest`).
+    # Remote Settings gira a ogni sessione, quindi l'occasione non e' rara.
+    #
+    # MISURATO il 2026-08-25 con un SOCKS5 locale che rifiuta apposta i due
+    # host e registra ogni CONNECT - e il registro E' il controllo, perche' 98
+    # CONNECT tutti per NOME dimostrano che la risoluzione remota funzionava:
+    #
+    #   senza questa pref  ->  43 rifiuti, e `firefox.settings.services.mozilla.com`
+    #                          RISOLTO 13 volte sul resolver di casa
+    #   con questa pref    ->  45 rifiuti, e ZERO risoluzioni locali; restano
+    #                          i soli `127.0.0.1`, `local`, `localhost`, cioe'
+    #                          lo stesso insieme di un SOCKS5 che non fallisce
+    #
+    # In entrambi i bracci la navigazione resta ok e il relay rilancia
+    # normalmente detectportal, push.services, normandy e il resto: la pref
+    # toglie il RIPIEGO, non il traffico.
+    #
+    # ⛔ VALE PER OGNI SCHEMA, HTTP COMPRESO, e sta DOPO il bivio apposta: le
+    # due validazioni (la porta, le credenziali che non si possono consegnare)
+    # devono poter sollevare PRIMA, lasciando il dict come l'hanno trovato. La
+    # prima stesura la metteva prima e sporcava le prefs su un endpoint
+    # malformato: due test esistenti sono diventati rossi e avevano ragione
+    # loro.
+    #
+    # Sul ramo HTTP questo NON e' una pref di instradamento e non tocca
+    # l'autenticazione: il contratto pinnato da
+    # `test_il_percorso_che_delega_NON_cambia_comportamento` diceva "chi delega
+    # non scrive prefs" per proteggere ROUTING e 407, e adesso lo dice con
+    # quelle parole invece che con `prefs == {}`.
+    prefs["network.proxy.allow_bypass"] = False
+
+    # ⛔ E LA SECONDA META', PERCHE' LA PRIMA NON BASTA SU HTTP.
+    #
+    # `allow_bypass` chiude i CANALI che ripiegano in diretta. Ma tre superfici
+    # non sono canali e chiamano `AsyncResolveNative` senza passare da nessun
+    # filtro: `NetworkConnectivityService`, le sonde dell'euristica DoH, e il
+    # resolver ICE. Il cancello del motore
+    # (`netwerk/dns/DNSServiceBase.cpp`, `DNSForbiddenByActiveProxy`) le
+    # fermerebbe, ma sa riconoscere solo un proxy scritto nelle
+    # `network.proxy.*` - e sul ramo HTTP non ne scriviamo nessuna, perche'
+    # instrada Playwright per canale. Quindi `network.proxy.type` resta 5 e il
+    # cancello non si arma.
+    #
+    # Il motore non puo' dedurlo: glielo diciamo noi. E' la regola 1 - il core
+    # dichiara, il motore obbedisce - applicata al DNS.
+    #
+    # MISURATO il 2026-08-25 dietro un proxy HTTP, due giri identici, con la
+    # sola `allow_bypass` gia' attiva: restavano `example.org` 28,
+    # `ipv4only.arpa` 12, `cloudflare-dns.com` 6 e - la peggiore -
+    # `stunprobe.invalid` 6, che e' un nome scelto DALLA PAGINA via
+    # `iceServers`. Dietro SOCKS gli stessi nomi facevano gia' 0.
+    #
+    # L'endpoint del proxy continua a risolversi: sia il livello SOCKS
+    # (`nsSOCKSIOLayer`) sia `DnsAndConnectSocket` chiedono la loro risoluzione
+    # con `RESOLVE_IGNORE_SOCKS_DNS`, che il cancello esenta per primo. Non e'
+    # una deroga che aggiungiamo noi: e' quella che gia' regge il ramo SOCKS.
+    prefs["zoom.stealth.dns.no_local_resolution"] = True
+    return risultato
+
+
+def _configure_socks(
+    proxy: Dict[str, str],
+    prefs: Dict[str, Any],
+    server: str,
+) -> None:
+    """Le prefs di instradamento SOCKS. Estratta da `configure_proxy` il
+    2026-08-25 perche' la pref di sicurezza qui sopra vive in UN posto solo e
+    doveva stare dopo la validazione di ENTRAMBI gli schemi."""
     host_port = _strip_scheme(server)
     if ":" not in host_port:
         # It used to `return None  # malformed, drop silently`, and a test named

--- a/src/invisible_core/constants.py
+++ b/src/invisible_core/constants.py
@@ -98,8 +98,9 @@ def ARCHIVE_NAME(platform_key: str, machine: str) -> str:
         return f"{BINARY_BASENAME}-win-{arch}.zip"
     if pk == "linux":
         return f"{BINARY_BASENAME}-linux-{arch}.tar.gz"
-    if pk == "darwin":
-        return f"{BINARY_BASENAME}-macos-{arch}.tar.gz"
+    # macOS non e' piu' supportato: nessun nome darwin si costruisce. I seal delle
+    # release vecchie contengono ancora asset darwin (letti dal ramo non-locale
+    # sopra, che prende il nome dal seal), ma un seal LOCALE non li produce piu'.
     raise NotImplementedError(f"unsupported platform: {platform_key}")
 
 

--- a/src/invisible_core/download.py
+++ b/src/invisible_core/download.py
@@ -282,31 +282,6 @@ def _extract(archive: Path, dst: Path) -> None:
         raise RuntimeError(f"unknown archive format: {archive}")
 
 
-def _post_extract_darwin(app_root: Path, entry: Path) -> None:
-    """Make an ad-hoc-signed .app launchable on macOS.
-
-    The .app is downloaded via requests (no Finder quarantine attached), but we
-    strip com.apple.quarantine defensively and ensure the inner binary is
-    executable. We exec the inner binary directly (not via LaunchServices), so
-    Gatekeeper's first-launch prompt does not apply; the ad-hoc signature
-    (applied in release.yml) is what lets the arm64 Mach-O run at all.
-    """
-    app = app_root
-    # walk up to the .app bundle dir if entry points inside it
-    for parent in entry.parents:
-        if parent.name.endswith(".app"):
-            app = parent
-            break
-    try:
-        subprocess.run(["xattr", "-dr", "com.apple.quarantine", str(app)], check=False)
-    except FileNotFoundError:
-        pass
-    try:
-        entry.chmod(0o755)
-    except OSError:
-        pass
-
-
 def _adopt_existing_cache(seal: Seal, asset: Asset, version_dir: Path) -> Path | None:
     """Use a tree that is already on disk if it IS the sealed build.
 
@@ -414,6 +389,15 @@ def ensure_binary(version: str | None = None, progress=None, status=None,
             f"the code never reads sends the reader hunting in the wrong function.)")
 
     plat = sys.platform
+    if plat == "darwin":
+        raise NotImplementedError(
+            "macOS non e' piu' una piattaforma supportata: da firefox-21 in poi non "
+            "vengono piu' pubblicati binari per Mac, e questo pacchetto non ne scarica.\n"
+            "I seal delle release precedenti contengono ancora gli asset macOS - restano "
+            "leggibili come storia - ma un nuovo avvio su Mac si ferma qui invece di "
+            "tentare un download che non esiste.\n"
+            "Su Windows e Linux non cambia niente."
+        )
     asset = seal.asset_for(plat, platform.machine())
     version_dir = cache_dir_for_seal(seal)
     entry = version_dir / asset.entry_rel

--- a/src/invisible_core/download.py
+++ b/src/invisible_core/download.py
@@ -438,8 +438,9 @@ def ensure_binary(version: str | None = None, progress=None, status=None,
         _extract(archive_path, tmp_dir)
 
     tmp_entry = tmp_dir / asset.entry_rel
-    if plat == "darwin":
-        _post_extract_darwin(tmp_dir, tmp_entry)
+    # (nessun post-extract per darwin: macOS rifiuta al confine sopra, quindi
+    #  questo percorso non e' piu' raggiungibile per un Mac. La funzione e' stata
+    #  rimossa con la fine del supporto macOS il 2026-08-26.)
     if not tmp_entry.exists():
         shutil.rmtree(tmp_dir, ignore_errors=True)
         raise RuntimeError(f"binary not found after extraction: {tmp_entry}")

--- a/src/invisible_core/launch.py
+++ b/src/invisible_core/launch.py
@@ -81,7 +81,14 @@ def build_launch_env(
     prefs: Dict[str, Any],
     *,
     timezone: Optional[str] = None,
-    egress_ip: Optional[str] = None,
+    #: L'indirizzo da DICHIARARE come srflx, oppure None per non dichiarare
+    #: niente. ⛔ NON e' l'IP di uscita, e il nome vecchio (`egress_ip`) lo
+    #: faceva credere: e' la decisione che `SessionGeo.srflx_da_dichiarare`
+    #: prende guardando le CAPACITA' dell'uscita. Il gemello nel wrapper
+    #: (`_session.build_env`) porta lo stesso nome apposta: erano gia' due
+    #: punti di atterraggio, e due nomi diversi avrebbero reso invisibile
+    #: che sono la stessa cosa.
+    srflx_dichiarato: Optional[str] = None,
     manifest_path: "Optional[str | os.PathLike[str]]" = None,
     base_env: Optional[Dict[str, str]] = None,
 ) -> Dict[str, str]:
@@ -112,7 +119,7 @@ def build_launch_env(
         # An already-set value in base_env wins, same rule as the WebRTC IP:
         # an A/B harness has to be able to point this somewhere else.
         env.setdefault("STEALTHFOX_FONT_MANIFEST", str(manifest_path))
-    webrtc_ip = env.get("STEALTHFOX_WEBRTC_PUBLIC_IP") or egress_ip
+    webrtc_ip = env.get("STEALTHFOX_WEBRTC_PUBLIC_IP") or srflx_dichiarato
     if webrtc_ip:
         env["STEALTHFOX_WEBRTC_PUBLIC_IP"] = webrtc_ip
         # SOLO dietro un proxy. Un Firefox retail dual-stack emette un srflx
@@ -333,7 +340,8 @@ def build_launch_plan(
     ).prefs
     pdir = Path(profile_dir)
     write_user_js(pdir, prefs)
-    env = build_launch_env(prefs, timezone=geo.timezone or None, egress_ip=geo.egress_ip)
+    env = build_launch_env(prefs, timezone=geo.timezone or None,
+                           srflx_dichiarato=geo.srflx_da_dichiarare())
     argv = [binary, "-no-remote", "-profile", str(pdir)]
     argv += list(extra_args or [])
     if url:

--- a/src/invisible_core/launch.py
+++ b/src/invisible_core/launch.py
@@ -115,6 +115,12 @@ def build_launch_env(
     webrtc_ip = env.get("STEALTHFOX_WEBRTC_PUBLIC_IP") or egress_ip
     if webrtc_ip:
         env["STEALTHFOX_WEBRTC_PUBLIC_IP"] = webrtc_ip
+        # SOLO dietro un proxy. Un Firefox retail dual-stack emette un srflx
+        # IPv6 con l'indirizzo globale VERO in chiaro (l'mDNS offusca solo gli
+        # host): dietro un proxy IPv4 sarebbe un leak e un'incoerenza, senza
+        # proxy e' semplicemente cio' che fa un browser normale. Misurato il
+        # 2026-08-25: retail 6 candidati, noi 3, perche' filtravamo sempre.
+        # Stessa riga e stessa ragione in `_session.build_env` del wrapper.
         env["STEALTHFOX_WEBRTC_DISABLE_IPV6"] = "1"
     return env
 

--- a/src/invisible_core/prefs.py
+++ b/src/invisible_core/prefs.py
@@ -411,13 +411,17 @@ _BASELINE: Dict[str, Any] = {
     #   §17.B), fed the egress IP via STEALTHFOX_WEBRTC_PUBLIC_IP from
     #   launcher._build_env (auto-discovered from the proxy).
     # IPv6: media.peerconnection.ice.disableIPv6 is DEAD on FF150 (read by no
-    #   ICE-gathering code). The real switch is our zoom.stealth.webrtc.disable_ipv6
-    #   (nICEr addrs.cpp filter) + the STEALTHFOX_WEBRTC_DISABLE_IPV6 env.
+    #   ICE-gathering code). Il filtro vero e' in nICEr (addrs.cpp), e dal
+    #   2026-08-25 legge UNA sola fonte: la variabile d'ambiente
+    #   STEALTHFOX_WEBRTC_DISABLE_IPV6, scritta incondizionatamente da
+    #   `launch.build_launch_env` e dal `_session.build_env` del wrapper.
+    #   La pref `zoom.stealth.webrtc.disable_ipv6` NON si scrive piu': il ponte
+    #   nativo non la legge, e una pref che nessun C++ legge e' proprio cio' che
+    #   `test_no_orphan_prefs_in_baseline` vieta di emettere.
     "media.peerconnection.enabled":                       True,
     "media.peerconnection.ice.no_host":                   False,
     "media.peerconnection.ice.default_address_only":      False,
     "media.peerconnection.ice.obfuscate_host_addresses":  True,
-    "zoom.stealth.webrtc.disable_ipv6":                   True,
     "media.peerconnection.ice.proxy_only":                False,
     "media.peerconnection.ice.relay_only":                False,
     "media.peerconnection.use_document_iceservers":       True,
@@ -651,20 +655,53 @@ _BASELINE: Dict[str, Any] = {
     "browser.contentblocking.report.lockwise.enabled":    False,
     "browser.contentblocking.report.monitor.enabled":     False,
     "dom.private-attribution.submission.enabled":         False,
+
     "browser.translations.enable":                        False,
 
-    # HTTP/3 + speculative + Alt-Svc disabled. SOCKS5 proxy doesn't
-    # support UDP ASSOCIATE so HTTP/3 fails. Speculative connections
-    # under load cause early channel cancel (NS_BINDING_FAILED).
-    "network.http.http3.enable":                          False,
-    "network.http.http3.enabled":                         False,
-    "network.http.altsvc.enabled":                        False,
-    "network.http.altsvc.oe":                             False,
+    # ⛔ QUI STAVANO SEI PREF CHE SPEGNEVANO HTTP/3, Alt-Svc, ECH e i record
+    # DNS HTTPS. TOLTE IL 2026-08-25: erano un segnale SOPPRESSO, e la ragione
+    # scritta accanto non reggeva alla misura.
+    #
+    # Il commento diceva: "SOCKS5 proxy doesn't support UDP ASSOCIATE so HTTP/3
+    # fails". Vero dietro un proxy - misurato: il gateway di un provider
+    # residenziale rifiuta `UDP ASSOCIATE` con `rep=7` su 8 peer su 8. Ma le
+    # pref erano INCONDIZIONATE, e senza proxy il proxy non c'entra niente.
+    #
+    # Misurato leggendo `performance.getEntriesByType('navigation')[0]
+    # .nextHopProtocol`, che e' il protocollo VERO della connessione, detto dal
+    # browser stesso:
+    #
+    #   senza proxy, come spedivamo   cloudflare-quic.com:  h2 -> h2 -> h2
+    #   senza proxy, pref tolte       cloudflare-quic.com:  h2 -> **h3** -> h3
+    #
+    # Cioe' eravamo l'unico browser sulla connessione a non parlare MAI HTTP/3,
+    # e Scrapfly lo stampa in chiaro (`http3_supported: false`). Un Firefox
+    # retail su una connessione di casa lo usa.
+    #
+    # **E dietro proxy non serve nessuna condizione**, che e' la parte che
+    # rende il rimedio semplice: con le pref al default del motore e un proxy
+    # configurato, Firefox **si astiene da solo**. Misurato su entrambi gli
+    # schemi, con e senza le pref, quattro corse: sempre `h2 -> h2 -> h2`, con
+    # gli stessi tempi (22-24 s). Non ci prova e fallisce: semplicemente non usa
+    # QUIC quando c'e' un proxy, esattamente come farebbe il retail.
+    #
+    # Il criterio, dettato dal proprietario lo stesso giorno: **si spegne una
+    # cosa solo se e' davvero indisponibile E non la si puo' falsificare.** Qui
+    # non e' indisponibile (senza proxy funziona) e dietro proxy se ne occupa il
+    # motore, quindi non c'e' niente da spegnere.
+    #
+    # `echconfig` e `use_https_rr_as_altsvc` valgono `true` nel motore e sono
+    # uscite con le altre: ECH cambia il ClientHello, cioe' proprio cio' che
+    # JA3/JA4 misurano, e un HTTPS RR in meno e' una via di scoperta che il
+    # retail ha e noi no.
+
+    # Le connessioni speculative RESTANO spente, e la ragione e' diversa: sotto
+    # carico producono un annullamento anticipato del canale
+    # (NS_BINDING_FAILED). E' un rimedio a un guasto osservato, non una difesa
+    # di fingerprint - e non e' stato rimisurato, quindi non si tocca.
     "network.predictor.enabled":                          False,
     "network.dns.disablePrefetch":                        True,
     "network.dns.disablePrefetchFromHTTPS":               True,
-    "network.dns.echconfig.enabled":                      False,
-    "network.dns.use_https_rr_as_altsvc":                 False,
 
     # === Fission / site-isolation disabled (FF146 Playwright parity) ===
     # Force a single content-process model. Three knobs are required in FF150:
@@ -1344,6 +1381,17 @@ def _apply_hardware(prefs: Dict[str, Any], profile: Profile) -> None:
     prefs["ui.prefersReducedMotion"]          = _a11y
     prefs["ui.prefersReducedTransparency"]    = _a11y
     prefs["ui.invertedColors"]                = _a11y
+    # La quarta della famiglia, aggiunta il 2026-08-24. Governa `forced-colors`
+    # e, di rimbalzo, `prefers-contrast`: quest'ultimo Gecko lo DERIVA dal
+    # rapporto di contrasto dei colori effettivi e non ha nessun override, ma il
+    # primo termine del suo if e' proprio questo flag.
+    #
+    # Era rimasta indietro perche' Playwright mandava `Browser.setForcedColors`
+    # a ogni lancio e l'override cortocircuitava la lettura: la pref non serviva
+    # a niente e nessuno si accorgeva che mancasse. Tolto quel comando, senza
+    # questa riga la decisione non sarebbe tornata qui - sarebbe andata
+    # all'HOST, via LookAndFeel::GetInt(IntID::UseAccessibilityTheme).
+    prefs["ui.useAccessibilityTheme"]         = _a11y
 
 
 def _apply_audio(prefs: Dict[str, Any], profile: Profile) -> None:
@@ -1501,6 +1549,19 @@ def _apply_fonts(prefs: Dict[str, Any], profile: Profile) -> None:
 def _apply_theme(prefs: Dict[str, Any], profile: Profile) -> None:
     """Dark mode, plus the Windows colours palette when the theme is light."""
     prefs["ui.systemUsesDarkTheme"] = int(profile.dark_theme)
+    # La stessa cosa detta all'altro lettore. `ui.systemUsesDarkTheme` la
+    # legge LookAndFeel; `prefers-color-scheme` no, perche' nsPresContext
+    # guarda prima l'override del BrowsingContext e poi questa pref.
+    # 0 = Dark, 1 = Light (StaticPrefList.yaml:10646-10648); il default e' 2,
+    # che vuol dire "il sistema", cioe' l'host.
+    #
+    # Dichiarata il 2026-08-24, quando `Browser.setColorScheme` e' stato tolto
+    # dal client. Va in quest'ordine: prima la dichiarazione, poi la rimozione
+    # del comando, altrimenti la decisione non torna qui - va alla macchina.
+    # Misurato prima: col comando attivo questa pref era codice morto, messa a
+    # 0 il browser continuava a rispondere light.
+    prefs["layout.css.prefers-color-scheme.content-override"] = (
+        0 if profile.dark_theme else 1)
     # ── Three LookAndFeel values that still read the HOST ────────────────────
     #
     # `ui.textScaleFactor` is the one that matters, and it is not a theme
@@ -1781,6 +1842,26 @@ def humanize_max_seconds(humanize: Any) -> float:
     return value if value > 0 else HUMANIZE_MAX_SECONDS
 
 
+#: Millisecondi fra due `mousemove` consecutivi, MEDIA di una gaussiana (il
+#: passo fisso era di per se' un tell, e il motore lo sfuma gia').
+#:
+#: Il valore non e' scelto a gusto: e' quello che il generatore Python del
+#: wrapper - il percorso PREDEFINITO, quindi il riferimento - produce davvero.
+#: Misurato il 2026-08-24 sulla stessa mossa, leggendo i `dt` dalla pagina:
+#: media 31,9 ms, mediana 31,5, minimo 16, e solo il 5% sotto i 16,7 ms.
+#:
+#: Il motore del binario, che e' il RIPIEGO quando il generatore Python manca,
+#: girava invece sul default compilato di 10 ms e dava media 14,2 ms con minimo
+#: 2 ms: **79 dt su 115 piu' fitti di quanto un 60 Hz reale possa consegnare**,
+#: perche' Firefox unisce i mousemove al ritmo di refresh. Due percorsi per la
+#: stessa cosa che si comportavano in modo diverso, e il piu' veloce era quello
+#: che nessun hardware puo' produrre.
+#:
+#: INTERO per forza: Juggler la legge con `getIntPref`, e una pref del tipo
+#: sbagliato arriva col nome giusto e non viene letta.
+HUMANIZE_STEP_MS = 32
+
+
 def humanize_prefs(humanize: Any) -> Dict[str, Any]:
     """The `stealthfox.*` prefs implied by a `humanize=` value.
 
@@ -1793,6 +1874,10 @@ def humanize_prefs(humanize: Any) -> Dict[str, Any]:
     return {
         "stealthfox.humanize": True,
         "stealthfox.humanize.maxTime": str(humanize_max_seconds(humanize)),
+        # Dichiarata qui e non lasciata al default compilato nel motore: era
+        # l'unica dei tre fratelli `stealthfox.humanize*` che il core non
+        # nominava, quindi la decideva il binario da solo.
+        "stealthfox.humanize.stepMs": HUMANIZE_STEP_MS,
     }
 
 

--- a/tests/test_consumer_contract.py
+++ b/tests/test_consumer_contract.py
@@ -157,6 +157,23 @@ CONTRACT = {
     },
     "invisible_core.download": {
         "cache_root", "ensure_binary",
+        # Le tre righe qui sotto sono entrate il 2026-08-24 con
+        # `invisible_playwright._node`, che procura il Node su cui gira il driver
+        # biforcato: lo scarica da nodejs.org al primo uso e ne verifica il
+        # checksum. Sono nomi PRIVATI, e listarli qui e' esattamente il punto:
+        # un consumatore che si appoggia a un nome privato senza dichiararlo
+        # crea una dipendenza che questo pacchetto puo' rompere senza
+        # accorgersene, ed e' quello che il gate ha appena impedito.
+        #
+        # Perche' appoggiarsi a loro invece di riscriverli nel wrapper: scaricare
+        # con una scadenza, sommare uno sha256 e leggere un file di checksum sono
+        # gia' scritti e gia' provati qui. Averne un secondo esemplare nel wrapper
+        # sarebbe lo stesso fatto in due posti - la regola 16 - e i due
+        # divergerebbero al primo bug corretto da una parte sola.
+        #
+        # Verificato che esistano nel wheel PUBBLICATO e non solo nell'albero di
+        # lavoro, perche' un consumatore puo' usare solo cio' che l'indice ha.
+        "_download_file", "_parse_checksums", "_sha256_file",
         # `engine_status` left on 2026-08-18 with the deletion of
         # `invisible_firefox`, which showed the engine's state in its UI. Not
         # deleted from the core and still covered by test_doctor_fix.py,

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -516,3 +516,118 @@ def test_a_single_endpoint_cannot_eat_the_whole_budget(monkeypatch):
         f"provato {len(visti)} endpoint su {len(_geo._IP_ECHO_ENDPOINTS)}: "
         "il budget si esaurisce sul primo e gli altri non entrano mai in gioco"
     )
+
+
+# ---------------------------------------------------------------------------
+# La decisione sul srflx viene dalle CAPACITA' dell'uscita, non dallo schema.
+# ---------------------------------------------------------------------------
+
+class _CapacitaFinte:
+    """Sostituisce la sonda di rete. Nessun proxy, nessun socket, nessuna attesa."""
+
+    def __init__(self, risposta):
+        self.risposta = risposta
+        self.chiamate = []
+
+    def __call__(self, proxy, **kw):
+        self.chiamate.append(kw)
+        if isinstance(self.risposta, Exception):
+            raise self.risposta
+        return self.risposta
+
+
+def _decidi(monkeypatch, risposta, egress="203.0.113.7"):
+    from invisible_core import _capacita, _geo
+    finta = _CapacitaFinte(risposta)
+    monkeypatch.setattr(_capacita, "capacita", finta)
+    return _geo._srflx_soppresso({"server": "socks5://gw:1080"}, egress), finta
+
+
+def test_il_DEFAULT_del_campo_e_quello_prudente():
+    """IL DIFETTO CHE QUESTO TEST ESISTE PER TENERE CHIUSO.
+
+    La prima stesura portava l'INDIRIZZO da dichiarare, con default ``None``.
+    `SessionGeo` si costruisce per posizione in sei punti fra codice e test, e
+    tutti quelli che non conoscevano il campo nuovo hanno smesso di dichiarare
+    il srflx per distrazione: il default cadeva dal lato che porta al messaggio
+    peggiore che un rilevatore possa scrivere. Invertito in un interruttore, il
+    silenzio va chiesto.
+    """
+    from invisible_core._geo import SessionGeo
+    g = SessionGeo("America/New_York", "198.51.100.4")
+    assert g.srflx_soppresso is False, "il default deve DICHIARARE"
+    assert g.srflx_da_dichiarare() == "198.51.100.4"
+
+
+def test_con_udp_coerente_il_srflx_si_SOPPRIME(monkeypatch):
+    """L'unico caso in cui tacere e' meglio che dichiarare.
+
+    Il srflx vero nascera' gia' con l'indirizzo giusto, perche' l'UDP esce da
+    dove esce il TCP. Dichiararne uno aggiungerebbe un candidato senza
+    allocazione corrispondente, che e' esattamente il segnale che un rilevatore
+    con un TURN proprio sa leggere.
+    """
+    from invisible_core._geo import SessionGeo
+    soppresso, _ = _decidi(monkeypatch, {"udp": True, "udp_coerente": True})
+    assert soppresso is True
+    assert SessionGeo("tz", "203.0.113.7", None, None, True).srflx_da_dichiarare() is None
+
+
+def test_con_udp_INCOERENTE_si_dichiara(monkeypatch):
+    """UDP c'e' ma esce da un altro indirizzo: il srflx vero porterebbe quello."""
+    soppresso, _ = _decidi(monkeypatch, {"udp": True, "udp_coerente": False})
+    assert soppresso is False
+
+
+def test_senza_udp_si_dichiara(monkeypatch):
+    soppresso, _ = _decidi(monkeypatch, {"udp": False, "udp_coerente": None})
+    assert soppresso is False
+
+
+def test_una_sonda_MUTA_non_e_una_licenza_a_tacere(monkeypatch):
+    """Campi assenti non sono una dimostrazione di coerenza."""
+    soppresso, _ = _decidi(monkeypatch, {})
+    assert soppresso is False
+
+
+def test_una_sonda_che_ESPLODE_non_puo_far_fallire_il_lancio(monkeypatch):
+    """Qualunque errore cade dal lato prudente, e il lancio prosegue."""
+    soppresso, _ = _decidi(monkeypatch, OSError("rete giu'"))
+    assert soppresso is False
+
+
+def test_l_uscita_gia_scoperta_viene_RIUSATA_non_rimisurata(monkeypatch):
+    """Un fatto, un giro. `prepare_session_geo` ha gia' pagato quel round-trip."""
+    _, finta = _decidi(monkeypatch, {"udp": False, "udp_coerente": None})
+    assert finta.chiamate, "la sonda non e' stata chiamata affatto"
+    assert finta.chiamate[0].get("uscita_tcp_nota") == "203.0.113.7"
+
+
+def test_senza_proxy_la_sonda_NON_viene_nemmeno_chiamata(monkeypatch):
+    """Su una connessione diretta lo STUN vero dice gia' la verita'."""
+    from invisible_core import _capacita, _geo
+    finta = _CapacitaFinte({"udp": True, "udp_coerente": True})
+    monkeypatch.setattr(_capacita, "capacita", finta)
+    assert _geo._srflx_soppresso(None, "203.0.113.7") is False
+    assert finta.chiamate == [], "sondare senza proxy e' un giro di rete sprecato"
+
+
+def test_la_domanda_riceve_risposta_in_UN_SOLO_posto():
+    """I due costruttori di env chiamano il metodo, non ricalcolano la regola."""
+    import inspect
+    from invisible_core import launch
+    src = inspect.getsource(launch.build_launch_env)
+    assert "srflx_soppresso" not in src, (
+        "build_launch_env sta rileggendo l'interruttore: la regola tornerebbe a "
+        "essere scritta in due posti, che e' come divergono")
+
+
+def test_la_stickiness_non_entra_piu_in_nessuna_decisione():
+    """Decisione del proprietario 2026-08-25, piu' il fatto che quel campo mentiva."""
+    import inspect
+    from invisible_core import _capacita
+    corpo = inspect.getsource(_capacita.misura)
+    corpo = corpo.split('"""')[2] if corpo.count('"""') >= 2 else corpo
+    assert "e_sticky" not in corpo, (
+        "la stickiness e' tornata dentro misura(): costava sei giri di rete su "
+        "otto e diceva 'si' per un endpoint misurato ruotare 8 volte in 25 minuti")

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -390,11 +390,27 @@ def test_prepare_geo_egress_present_even_with_explicit_tz(stub_egress):
 
 
 @pytest.mark.unit
-def test_prepare_geo_no_egress_without_proxy(stub_egress):
-    # no proxy → no WebRTC override (real STUN already tells the truth).
+def test_prepare_geo_no_webrtc_override_without_proxy(stub_egress):
+    """Senza proxy non si dichiara nessun srflx - ma il fatto si porta lo stesso.
+
+    ⛔ QUESTO TEST ASSERIVA IL MECCANISMO, NON IL REQUISITO. Il commento diceva
+    "no WebRTC override (real STUN already tells the truth)", che e' il
+    requisito e vale ancora; l'asserzione era `geo.egress_ip is None`, che era
+    solo il MODO in cui quel requisito veniva ottenuto fino al 2026-08-26.
+    Quel modo costava una seconda scoperta dell'indirizzo, perche' il fatto
+    veniva buttato per poter dire "non dichiarare".
+
+    Adesso il requisito e' asserito direttamente, e il fatto e' asserito come
+    fatto. Sono due righe che prima erano una sola e ambigua.
+    """
     geo = prepare_session_geo("auto", None)
     assert geo.timezone == "America/New_York"
-    assert geo.egress_ip is None
+    assert geo.srflx_da_dichiarare() is None, (
+        "senza proxy il motore non deve ricevere nessun srflx da dichiarare: "
+        "quello vero nasce gia' con l'indirizzo giusto e con la sua allocazione")
+    assert geo.egress_ip == "203.0.113.7", (
+        "il giro di rete e' stato fatto per il fuso: buttarne il risultato "
+        "obbliga resolve_session_locale a rifarlo")
 
 
 @pytest.mark.unit
@@ -617,11 +633,18 @@ def test_l_uscita_gia_scoperta_viene_RIUSATA_non_rimisurata(monkeypatch):
 
 
 def test_senza_proxy_la_sonda_NON_viene_nemmeno_chiamata(monkeypatch):
-    """Su una connessione diretta lo STUN vero dice gia' la verita'."""
+    """Su una connessione diretta lo STUN vero dice gia' la verita'.
+
+    ⛔ E QUELLA FRASE E' IL REQUISITO, quindi la risposta e' `True` - non
+    dichiarare. Fino al 2026-08-26 questa asserzione diceva `False`, e il "non
+    dichiarare" arrivava lo stesso perche' `egress_ip` valeva `None` senza
+    proxy. Docstring e asserzione dicevano cose opposte su cosa fare con un
+    indirizzo in mano, e a decidere era l'assenza del fatto invece della regola.
+    """
     from invisible_core import _capacita, _geo
     finta = _CapacitaFinte({"udp": True, "udp_coerente": True})
     monkeypatch.setattr(_capacita, "capacita", finta)
-    assert _geo._srflx_soppresso(None, "203.0.113.7") is False
+    assert _geo._srflx_soppresso(None, "203.0.113.7") is True
     assert finta.chiamate == [], "sondare senza proxy e' un giro di rete sprecato"
 
 
@@ -693,3 +716,111 @@ def test_l_instradamento_udp_e_dichiarato_in_un_posto_solo():
         "scritto in due posti")
     assert "Preferences" not in codice and "socks_remote_udp" not in codice, (
         "_geo sta leggendo la pref per conto suo invece della costante")
+
+
+def _conta_scoperte(monkeypatch):
+    """Rende la scoperta deterministica e CONTA quante volte viene chiamata."""
+    import invisible_core.download as dl
+    from invisible_core import _geo
+
+    conteggio = {"n": 0}
+
+    def finta(proxy=None, **kw):
+        conteggio["n"] += 1
+        return "203.0.113.7"
+
+    monkeypatch.setattr(_geo, "discover_egress_ip", finta)
+    monkeypatch.setattr(_geo, "ip_to_timezone", lambda ip, mmdb: "America/New_York")
+    monkeypatch.setattr(_geo, "ip_to_locale", lambda ip, mmdb: "en-GB")
+    monkeypatch.setattr(_geo, "ip_to_coordinates", lambda ip, mmdb: (1.0, 2.0))
+    monkeypatch.setattr(dl, "ensure_geoip_mmdb", lambda *a, **k: "fake.mmdb")
+    return conteggio
+
+
+@pytest.mark.unit
+def test_senza_proxy_l_indirizzo_si_scopre_UNA_volta_sola(monkeypatch):
+    """Un fatto, un giro di rete. Il percorso predefinito ne faceva DUE.
+
+    ⛔ E' LA REGOLA 16 APPLICATA A UN GIRO DI RETE. `prepare_session_geo`
+    scopriva l'indirizzo per derivarne il fuso, poi lo buttava perche' il campo
+    che avrebbe potuto portarlo significava un'altra cosa; `resolve_session_locale`
+    doveva quindi riscoprirlo. Due richieste identiche a un servizio esterno,
+    dall'indirizzo VERO, prima che il browser esista - e un utente vero ne fa
+    zero, non due.
+
+    Il conto va fatto sui DUE passi insieme, perche' ognuno preso da solo era
+    gia' corretto: nessuno dei due faceva un giro di troppo. Il difetto stava
+    fra loro, e un test su una funzione sola non poteva vederlo.
+    """
+    from invisible_core import _geo
+
+    conteggio = _conta_scoperte(monkeypatch)
+    geo = _geo.prepare_session_geo("auto", None)
+    loc = _geo.resolve_session_locale(geo.egress_ip, None)
+
+    assert loc == "en-GB", "la lingua deve comunque risolversi dall'indirizzo"
+    assert conteggio["n"] == 1, (
+        "l'indirizzo e' stato chiesto alla rete %d volte invece di una: il "
+        "fatto viene ancora buttato fra un passo e l'altro" % conteggio["n"])
+
+
+@pytest.mark.unit
+def test_senza_proxy_il_motore_non_riceve_ne_srflx_ne_filtro_ipv6(monkeypatch):
+    """⛔ LA REGRESSIONE CHE LA CORREZIONE OVVIA AVREBBE CAUSATO.
+
+    Portare l'indirizzo scoperto dentro `egress_ip` senza toccare altro sembra
+    la correzione minima del doppio giro, e sarebbe stata un guasto doppio,
+    perche' `egress_ip` pilotava DUE cose:
+
+    1. il srflx dichiarato - avremmo annunciato un candidato sintetico con
+       l'indirizzo di CASA, cioe' un candidato senza allocazione corrispondente,
+       che e' esattamente il segnale che il rilevatore letto in
+       `docs_research/scrapfly-re/` chiama "the front end is manipulated";
+    2. il filtro IPv6 - `build_launch_env` lo accende su `if webrtc_ip`, quindi
+       si sarebbe riacceso anche senza proxy, disfacendo la misura del
+       2026-08-25 (retail 6 candidati, noi 3, perche' filtravamo sempre).
+
+    Nessuna delle due si vede da un test sul solo `_geo`: la prima passa per un
+    metodo, la seconda per un costruttore di ambiente in un altro modulo. Per
+    questo il test arriva fino all'ambiente.
+    """
+    from invisible_core import _geo
+    from invisible_core.launch import build_launch_env
+
+    _conta_scoperte(monkeypatch)
+    geo = _geo.prepare_session_geo("auto", None)
+
+    assert geo.egress_ip == "203.0.113.7", "il fatto deve essere in mano"
+    env = build_launch_env({}, timezone=geo.timezone or None,
+                           srflx_dichiarato=geo.srflx_da_dichiarare(),
+                           base_env={})
+
+    assert "STEALTHFOX_WEBRTC_PUBLIC_IP" not in env, (
+        "senza proxy staremmo dichiarando un srflx sintetico con l'indirizzo "
+        "di casa: un candidato senza allocazione corrispondente")
+    assert "STEALTHFOX_WEBRTC_DISABLE_IPV6" not in env, (
+        "senza proxy il filtro IPv6 si e' riacceso: e' la regressione della "
+        "misura del 2026-08-25, retail 6 candidati contro i nostri 3")
+
+
+@pytest.mark.unit
+def test_dietro_un_proxy_una_scoperta_fallita_NON_cade_sull_indirizzo_diretto(monkeypatch):
+    """La lingua non si deriva mai dal paese di casa mentre il fuso dice un altro.
+
+    E' il rischio dell'altra meta' della correzione: `resolve_session_locale`
+    adesso riusa cio' che riceve invece di riscoprirlo, e la forma piu' breve -
+    `ip = egress_ip or discover_egress_ip(None)` - avrebbe fatto cadere il caso
+    "proxy vivo, scoperta fallita" sull'indirizzo DIRETTO. La sessione avrebbe
+    dichiarato la lingua del paese di casa e il fuso di quello del proxy: una
+    contraddizione fra due campi, che e' peggio del ripiego su `en-US`.
+    """
+    from invisible_core import _geo
+
+    conteggio = _conta_scoperte(monkeypatch)
+    conteggio["n"] = 0
+    loc = _geo.resolve_session_locale(None, {"server": "socks5://g:1"})
+
+    assert loc == "en-US", "dietro un proxy senza indirizzo si ripiega, non si indovina"
+    assert conteggio["n"] == 0, (
+        "e' uscito sulla rete DIRETTA per derivare la lingua mentre un proxy "
+        "era configurato: quell'indirizzo e' quello di casa")

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -568,6 +568,11 @@ def test_con_udp_coerente_il_srflx_si_SOPPRIME(monkeypatch):
     con un TURN proprio sa leggere.
     """
     from invisible_core._geo import SessionGeo
+    from invisible_core import _proxy
+    # ⛔ SERVONO DUE CONDIZIONI, non una: che l'uscita porti UDP coerente E che
+    # il browser quell'UDP lo mandi dentro il proxy. Questo test ne provava una
+    # sola, e per un'ora la funzione ne controllava una sola.
+    monkeypatch.setattr(_proxy, "INSTRADIAMO_UDP_NEL_SOCKS", True)
     soppresso, _ = _decidi(monkeypatch, {"udp": True, "udp_coerente": True})
     assert soppresso is True
     assert SessionGeo("tz", "203.0.113.7", None, None, True).srflx_da_dichiarare() is None
@@ -597,7 +602,15 @@ def test_una_sonda_che_ESPLODE_non_puo_far_fallire_il_lancio(monkeypatch):
 
 
 def test_l_uscita_gia_scoperta_viene_RIUSATA_non_rimisurata(monkeypatch):
-    """Un fatto, un giro. `prepare_session_geo` ha gia' pagato quel round-trip."""
+    """Un fatto, un giro. `prepare_session_geo` ha gia' pagato quel round-trip.
+
+    ⛔ Serve accendere l'instradamento, perche' con quello spento la sonda non
+    viene chiamata AFFATTO - ed e' giusto cosi': se il browser non manda l'UDP
+    dentro il proxy, sapere che il proxy lo porterebbe non cambia nessuna
+    decisione, e quei 4-19 secondi sarebbero spesi per niente.
+    """
+    from invisible_core import _proxy
+    monkeypatch.setattr(_proxy, "INSTRADIAMO_UDP_NEL_SOCKS", True)
     _, finta = _decidi(monkeypatch, {"udp": False, "udp_coerente": None})
     assert finta.chiamate, "la sonda non e' stata chiamata affatto"
     assert finta.chiamate[0].get("uscita_tcp_nota") == "203.0.113.7"
@@ -631,3 +644,52 @@ def test_la_stickiness_non_entra_piu_in_nessuna_decisione():
     assert "e_sticky" not in corpo, (
         "la stickiness e' tornata dentro misura(): costava sei giri di rete su "
         "otto e diceva 'si' per un endpoint misurato ruotare 8 volte in 25 minuti")
+
+
+def test_udp_coerente_NON_basta_se_il_browser_non_instrada_l_udp_nel_proxy(monkeypatch):
+    """⛔ IL DIFETTO DELLA PRIMA STESURA, del 2026-08-25.
+
+    Che l'USCITA porti UDP coerente non basta: deve anche essere il BROWSER a
+    mandarci l'UDP. Con `network.proxy.socks_remote_udp` spenta l'UDP scavalca
+    il proxy, quindi il srflx VERO nascerebbe con l'indirizzo di casa, e
+    smettere di dichiarare sarebbe una fuga invece di un rimedio.
+
+    Il ramo era irraggiungibile per FORTUNA - nessun fornitore ha UDP usabile -
+    e non per costruzione. E' la forma di difetto che questo progetto paga: una
+    condizione la cui sicurezza dipende da un fatto che non verifica.
+    """
+    from invisible_core import _capacita, _geo, _proxy
+
+    monkeypatch.setattr(_capacita, "capacita",
+                        lambda p, **k: {"udp": True, "udp_coerente": True})
+
+    monkeypatch.setattr(_proxy, "INSTRADIAMO_UDP_NEL_SOCKS", False)
+    assert _geo._srflx_soppresso({"server": "socks5://g:1"}, "203.0.113.7") is False, (
+        "senza instradamento dell'UDP nel proxy si DEVE continuare a dichiarare")
+
+    monkeypatch.setattr(_proxy, "INSTRADIAMO_UDP_NEL_SOCKS", True)
+    assert _geo._srflx_soppresso({"server": "socks5://g:1"}, "203.0.113.7") is True, (
+        "con l'instradamento acceso E l'UDP coerente il ramo deve accendersi, "
+        "altrimenti la costante non e' una condizione ma un interruttore morto")
+
+
+def test_l_instradamento_udp_e_dichiarato_in_un_posto_solo():
+    """Il fatto non deve essere riscritto: si legge dalla costante."""
+    import inspect
+    from invisible_core import _geo, _proxy
+
+    assert _proxy.INSTRADIAMO_UDP_NEL_SOCKS is False, (
+        "se un giorno si accende, va acceso QUI e la pref "
+        "network.proxy.socks_remote_udp va emessa nello stesso commit")
+    # ⛔ IL CONTROLLO VA SUL CODICE, NON SUL COMMENTO. La prima stesura di
+    # questo test cercava la stringa `socks_remote_udp` nel sorgente della
+    # funzione e la trovava nel COMMENTO che spiega perche' la costante esiste.
+    # E' la regola piu' ripetuta di questo progetto, applicata al contrario.
+    righe = [r.split("#")[0] for r in
+             inspect.getsource(_geo._srflx_soppresso).splitlines()]
+    codice = chr(10).join(righe)
+    assert "INSTRADIAMO_UDP_NEL_SOCKS" in codice, (
+        "la decisione non legge la costante: il fatto tornerebbe a essere "
+        "scritto in due posti")
+    assert "Preferences" not in codice and "socks_remote_udp" not in codice, (
+        "_geo sta leggendo la pref per conto suo invece della costante")

--- a/tests/test_headless.py
+++ b/tests/test_headless.py
@@ -42,10 +42,16 @@ def test_make_virtual_display_returns_none_on_win32(monkeypatch):
 
 
 @pytest.mark.unit
-def test_make_virtual_display_returns_none_on_darwin(monkeypatch):
-    """macOS is now supported - it hides via the same in-binary cloak pref."""
+def test_make_virtual_display_raises_on_darwin(monkeypatch):
+    """macOS non e' piu' supportato: un Mac si ferma qui invece di procedere.
+
+    Fino a firefox-20 tornava ``None`` (il binario si nascondeva da solo via
+    ``cloak_prefs()``). Da firefox-21 il Mac non e' piu' un target: il rifiuto
+    va dato al confine, con un messaggio che nomina il perche', non lasciato a
+    un fallimento oscuro piu' a valle."""
     monkeypatch.setattr(headless.sys, "platform", "darwin")
-    assert make_virtual_display() is None
+    with pytest.raises(RuntimeError, match="macOS non e' piu' supportato"):
+        make_virtual_display()
 
 
 @pytest.mark.unit
@@ -67,7 +73,7 @@ def test_make_virtual_display_accepts_linux_variants(monkeypatch):
 @pytest.mark.unit
 def test_make_virtual_display_raises_on_unsupported_platform(monkeypatch):
     monkeypatch.setattr(headless.sys, "platform", "freebsd14")
-    with pytest.raises(RuntimeError, match="Windows, macOS and Linux"):
+    with pytest.raises(RuntimeError, match="Windows e Linux"):
         make_virtual_display()
 
 

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -73,7 +73,7 @@ def test_build_launch_env_no_font_env_but_webrtc():
     # so build_launch_env must NOT set any STEALTHFOX_FONTLIST/SYSTEMUI env - even
     # when legacy font prefs are passed. WebRTC egress + TZ are still wired.
     prefs = {"zoom.stealth.font.fontlist": "Arial,Calibri", "zoom.stealth.font.system_ui": "Segoe UI"}
-    env = build_launch_env(prefs, timezone="America/New_York", egress_ip="198.51.100.4", base_env={})
+    env = build_launch_env(prefs, timezone="America/New_York", srflx_dichiarato="198.51.100.4", base_env={})
     assert "STEALTHFOX_FONTLIST" not in env
     assert "STEALTHFOX_SYSTEMUI" not in env
     assert env["STEALTHFOX_WEBRTC_PUBLIC_IP"] == "198.51.100.4"
@@ -88,5 +88,5 @@ def test_build_launch_env_no_proxy_no_webrtc_no_tz():
 
 
 def test_build_launch_env_caller_webrtc_wins():
-    env = build_launch_env({}, egress_ip="203.0.113.9", base_env={"STEALTHFOX_WEBRTC_PUBLIC_IP": "198.51.100.1"})
+    env = build_launch_env({}, srflx_dichiarato="203.0.113.9", base_env={"STEALTHFOX_WEBRTC_PUBLIC_IP": "198.51.100.1"})
     assert env["STEALTHFOX_WEBRTC_PUBLIC_IP"] == "198.51.100.1"

--- a/tests/test_marker_vocabulary.py
+++ b/tests/test_marker_vocabulary.py
@@ -55,6 +55,21 @@ pytestmark = pytest.mark.unit
 _REPOS = ["invisible_core", "invisible_playwright"]
 _RELEASE = Path(__file__).resolve().parents[2]
 
+
+def _e_vendorizzato(rel: str) -> bool:
+    """Il file appartiene al fork Playwright vendorizzato (``_pw`` o ``_driver``)?
+
+    Da quando il fork e' in git (2026-08-26, voce 23 di 72-next-steps.md), questi
+    controlli lo scansionano insieme al nostro codice. Ma il fork non e' nostro:
+    il suo ``_pw/_impl/_transport.py`` usa sequenze ANSI ``\\x1b[...`` per colorare
+    l'output di terminale, byte pulite ma il cui VALORE contiene 0x1B. Questo gate
+    esiste per cogliere la NOSTRA corruzione da heredoc, non per fare il linter del
+    codice di Microsoft: il fork si esclude, come ``tests/playwright-upstream`` e'
+    gia' escluso dall'sdist per la stessa ragione (non e' roba nostra).
+    """
+    parti = rel.replace("\\", "/").split("/")
+    return "_pw" in parti or "_driver" in parti
+
 # Where the patched Firefox source lives, per `10-repo-layout.md`. Two entries
 # because the two build trees are SEPARATE clones, Windows and WSL. Only used
 # to resolve test names the workbench docs cite from that repo; a machine that
@@ -551,6 +566,8 @@ def test_no_tracked_text_file_carries_an_invisible_control_character():
         names = [n for n in listing.stdout.splitlines() if n.strip()]
         assert names, f"{repo}: git tracks no files, so this check saw nothing"
         for rel in names:
+            if _e_vendorizzato(rel):
+                continue
             path = root / rel
             if path.suffix.lower() not in _TEXT_SUFFIXES or not path.is_file():
                 continue
@@ -618,6 +635,8 @@ def test_no_string_LITERAL_evaluates_to_a_control_character():
         names = [n for n in listing.stdout.splitlines() if n.strip()]
         assert names, f"{repo}: git tracks no Python files; this check saw nothing"
         for rel in names:
+            if _e_vendorizzato(rel):
+                continue
             path = root / rel
             if not path.is_file():
                 continue

--- a/tests/test_prefs_composition.py
+++ b/tests/test_prefs_composition.py
@@ -82,6 +82,12 @@ DELIBERATE = {
     # has no trajectory generator of their own, so the binary's is left on.
     "stealthfox.humanize",
     "stealthfox.humanize.maxTime",
+    # Terzo fratello, stessa ragione dei due sopra: governa la cadenza del
+    # generatore DEL BINARIO, che solo il percorso pubblico accende. Prima non
+    # era dichiarato da nessuno e il motore usava il proprio default compilato
+    # di 10 ms, che misurato dava il 79% degli intervalli piu' fitti di quanto
+    # un 60 Hz reale possa consegnare.
+    "stealthfox.humanize.stepMs",
 }
 
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -367,12 +367,31 @@ def test_una_password_senza_username_e_comunque_una_credenziale():
 def test_il_percorso_che_delega_NON_cambia_comportamento():
     """Guardia di regressione sul ramo misurato verde: il wrapper passa il dict a
     Playwright, che instrada e risponde al 407. Se questo caso si muove, si e'
-    rotto l'unico percorso HTTP che funziona per gli utenti."""
+    rotto l'unico percorso HTTP che funziona per gli utenti.
+
+    ⛔ IL CONTRATTO E' SULLE PREFS DI INSTRADAMENTO, non su "nessuna pref", e
+    fino al 2026-08-25 era scritto `prefs == {}`. Cio' che va protetto e' che
+    non scriviamo noi il ROUTING (`type`, `http`, `ssl`, `socks*`), perche' quel
+    ramo lo instrada Playwright ed e' l'unico che sa rispondere al 407.
+
+    E' cambiato perche' `network.proxy.allow_bypass` deve valere anche qui: non
+    instrada niente e non tocca l'autenticazione, toglie solo a Firefox il
+    ripiego DIRETTO quando il proxy fallisce. Con `prefs == {}` il ramo HTTP
+    sarebbe restato scoperto proprio sul difetto misurato quel giorno.
+    """
+    instradamento = ("network.proxy.type", "network.proxy.http",
+                     "network.proxy.http_port", "network.proxy.ssl",
+                     "network.proxy.ssl_port", "network.proxy.socks",
+                     "network.proxy.socks_port", "network.proxy.socks_version",
+                     "network.proxy.socks_remote_dns")
     for creds in ({}, {"username": "u", "password": "p"}):
         proxy = dict({"server": "http://gw.esempio:8080"}, **creds)
         prefs = {}
         assert configure_proxy(proxy, prefs) is proxy
-        assert prefs == {}, "chi delega non deve scrivere prefs di proxy"
+        scritte = [k for k in prefs if k in instradamento]
+        assert not scritte, f"chi delega non deve instradare da se': {scritte}"
+        assert prefs.get("network.proxy.allow_bypass") is False, (
+            "il ramo HTTP resta senza la difesa dal ripiego diretto")
 
 
 def test_un_http_senza_porta_e_rifiutato_anche_qui():
@@ -424,3 +443,101 @@ def test_il_lancio_diretto_dichiara_di_non_poter_delegare():
         assert kw["delegates_auth"].value is False, (
             "delegates_auth c'e' ma non e' False: questo percorso Playwright non "
             "ce l'ha")
+def test_dietro_qualunque_proxy_il_ripiego_diretto_e_spento():
+    """Il ripiego di Firefox a un proxy che fallisce e' una connessione DIRETTA.
+
+    `network.proxy.allow_bypass` vale `true` di default nella nostra build, e un
+    canale che chiede `bypassProxy` salta `ResolveProxy()`: risolve col resolver
+    dell'utente e si connette col suo IP, proprio mentre il proxy sta fallendo.
+    I due consumatori sono `fallbackOrReject` di Remote Settings e `retryRequest`
+    della telemetria, e Remote Settings gira a ogni sessione.
+
+    Misurato il 2026-08-25 con un SOCKS5 locale che rifiuta apposta quei due
+    host: senza la pref, 43 rifiuti e l'host di Remote Settings risolto 13 volte
+    in locale; con la pref, 45 rifiuti e ZERO risoluzioni locali, cioe' lo stesso
+    insieme di nomi di un SOCKS5 che non fallisce. La navigazione resta ok in
+    entrambi i bracci.
+
+    Si asserisce su OGNI SCHEMA, non sul solo SOCKS: il difetto non dipende
+    dalla versione di SOCKS e nemmeno dal fatto che sia SOCKS. Decisione del
+    proprietario 2026-08-25, "dobbiamo permettere di usare tutti i protocolli":
+    la difesa vale ovunque, invece di essere una ragione per escludere uno
+    schema.
+    """
+    from invisible_core import configure_proxy
+
+    for server in ("socks5://h:1080", "socks4://h:1080", "socks://h:1080",
+                   "http://h:8080", "https://h:8443"):
+        prefs = {}
+        configure_proxy({"server": server}, prefs)
+        assert prefs.get("network.proxy.allow_bypass") is False, (
+            f"{server}: senza questa pref, un fallimento del proxy fa uscire "
+            f"Firefox in diretta con l'IP vero")
+
+
+def test_dietro_qualunque_proxy_il_dns_locale_e_dichiarato_vietato():
+    """`allow_bypass` chiude i CANALI. Questa chiude cio' che canale non e'.
+
+    Tre superfici chiamano `AsyncResolveNative` diretto e non passano da nessun
+    filtro: `NetworkConnectivityService`, le sonde dell'euristica DoH, e il
+    resolver ICE. Il cancello del motore le fermerebbe
+    (`netwerk/dns/DNSServiceBase.cpp`, `DNSForbiddenByActiveProxy`) ma riconosce
+    solo un proxy scritto nelle `network.proxy.*`, e sul ramo HTTP non ne
+    scriviamo nessuna. Quindi il fatto lo dichiara il core: regola 1.
+
+    La peggiore delle tre e' il resolver ICE, perche' il nome lo sceglie LA
+    PAGINA via `iceServers`: senza questa pref, dietro un proxy HTTP un sito
+    puo' far risolvere al browser un nome suo e guardare quale resolver
+    interroga, cioe' quello di casa, mentre l'HTTP esce dal proxy.
+
+    Misurato il 2026-08-25 dietro proxy HTTP, due giri identici: senza la pref
+    21 nomi risolti in locale fra cui `stunprobe.invalid` 6; con la pref **3**,
+    cioe' `local`, `localhost` e l'endpoint del proxy - la stessa identica forma
+    del braccio SOCKS. Il braccio senza proxy resta a 28 nomi: la pref li' non
+    viene scritta e il motore si comporta come upstream.
+    """
+    from invisible_core import configure_proxy
+
+    for server in ("socks5://h:1080", "socks4://h:1080", "socks://h:1080",
+                   "http://h:8080", "https://h:8443"):
+        prefs = {}
+        configure_proxy({"server": server}, prefs)
+        assert prefs.get("zoom.stealth.dns.no_local_resolution") is True, (
+            f"{server}: senza questa dichiarazione una PAGINA puo' far "
+            f"risolvere al browser un nome scelto da lei sul resolver di casa")
+
+
+def test_senza_proxy_il_ripiego_non_si_dichiara():
+    """Il caso che deve NON scattare, e vale quanto quello che scatta.
+
+    Senza proxy non c'e' niente da aggirare, quindi la pref non ha nulla da
+    governare e dichiararla sarebbe una divergenza dal retail pagata per zero.
+    Stessa forma per `direct://`, che e' un modo di dire "nessun proxy".
+    """
+    from invisible_core import configure_proxy
+
+    for proxy in (None, {}, {"server": ""}, {"server": "direct://"}):
+        prefs = {}
+        configure_proxy(proxy, prefs)
+        assert "network.proxy.allow_bypass" not in prefs, (
+            f"{proxy!r}: pref dichiarata dove non c'e' proxy da aggirare")
+        assert "zoom.stealth.dns.no_local_resolution" not in prefs, (
+            f"{proxy!r}: senza proxy il DNS locale e' il percorso NORMALE, e "
+            f"vietarlo sarebbe una divergenza dal retail pagata per zero")
+
+
+def test_un_endpoint_malformato_non_lascia_prefs_a_meta():
+    """Il rifiuto deve lasciare il dict come l'ha trovato.
+
+    La prima stesura scriveva `allow_bypass` PRIMA di validare la porta, quindi
+    un endpoint malformato sollevava lasciandosi dietro una pref: un dict
+    parzialmente configurato che il chiamante puo' usare credendolo intatto. Due
+    test esistenti sono diventati rossi e avevano ragione loro.
+    """
+    import pytest
+    from invisible_core import configure_proxy
+
+    prefs = {}
+    with pytest.raises(ValueError):
+        configure_proxy({"server": "socks5://senzaporta"}, prefs)
+    assert prefs == {}, f"prefs sporcate dal rifiuto: {prefs}"

--- a/tests/test_seal_download.py
+++ b/tests/test_seal_download.py
@@ -78,10 +78,14 @@ APP_INI = ("[App]\nVendor=Mozilla\nName=Firefox\nVersion={v}\nBuildID={b}\n\n"
            "[Gecko]\nMinVersion={v}\nMaxVersion={v}\n")
 PLAT_INI = "[Build]\nBuildID={b}\nMilestone={v}\n"
 
+# macOS non e' piu' un target di download: dal 2026-08-26 `ensure_binary` rifiuta
+# su darwin PRIMA di guardare il seal (che per le release vecchie contiene ancora
+# gli asset mac - restano leggibili come storia, ma non si scaricano piu'). La
+# gamba darwin e' quindi uscita da questa lista; il rifiuto ha un test suo,
+# `test_ensure_binary_rifiuta_macos`, piu' sotto.
 PLATFORMS = [
     pytest.param("win32", id="win32-zip"),
     pytest.param("linux", id="linux-targz-loose-juggler"),
-    pytest.param("darwin", id="darwin-targz-bundle"),
 ]
 
 
@@ -678,3 +682,21 @@ def test_the_download_path_never_installs_anything():
         "the engine download path reaches an installer again:\n  "
         + "\n  ".join(hits) +
         "\n\nIt may report what to run. It may not run it.")
+
+
+@pytest.mark.unit
+def test_ensure_binary_rifiuta_macos(cache, tmp_path, monkeypatch):
+    """Su un Mac ``ensure_binary`` si ferma al confine, non tenta un download.
+
+    macOS non e' piu' un target dal 2026-08-26. Il rifiuto arriva PRIMA di
+    guardare il seal, con un messaggio che nomina il perche' (nessun binario mac
+    pubblicato) invece di lasciare un fallimento oscuro piu' a valle. Il seal
+    passato e' non-locale e valido (una gamba linux/win reale), per superare il
+    controllo ``is_local`` e arrivare al ramo di piattaforma: e' quel ramo a
+    rifiutare, non l'assenza di un asset.
+    """
+    plat = "win32" if sys.platform == "win32" else "linux"
+    seal, _name, _bytes, _bid = publish(tmp_path, plat)
+    monkeypatch.setattr(sys, "platform", "darwin")
+    with pytest.raises(NotImplementedError, match="macOS non e' piu' una piattaforma"):
+        ensure_binary(seal=seal)


### PR DESCRIPTION
macOS esce dal supporto: ensure_binary rifiuta su Mac al confine con un messaggio chiaro, prima di guardare il seal. Il parser del seal resta, perche' i seal storici contengono ancora asset darwin e vanno letti su Win/Linux. Tolti i rami darwin morti (post-extract, ARCHIVE_NAME, la tupla di _headless).

Piu' il fix del doppio giro: senza proxy l'indirizzo di uscita si scopriva due volte prima del lancio, perche' il campo che poteva portarlo aveva due significati. Separati il fatto dalla decisione.

937 test verdi, incluso il nuovo test_ensure_binary_rifiuta_macos.