### PR TITLE
Release 20.16.0

### DIFF
--- a/src/invisible_core/_version.py
+++ b/src/invisible_core/_version.py
@@ -9,7 +9,7 @@ reset it: pip compares with != , not <.
 import json
 import pathlib
 
-CORE_REVISION = 15
+CORE_REVISION = 16
 
 _seal = json.loads(
     pathlib.Path(__file__).with_name("seal.json").read_text(encoding="utf-8")


### PR DESCRIPTION
Bump CORE_REVISION 15 -> 16 per il rilascio solo-core sul motore firefox-20. Porta agli utenti la fine del supporto macOS, il fix del doppio giro di scoperta IP e le correzioni WebRTC lato Python. version_gate check: PUBLISH ALLOWED.