### PR TITLE
The pre-push refusal named one cause for every kind of gate failure

### DIFF
--- a/src/invisible_core/_version.py
+++ b/src/invisible_core/_version.py
@@ -9,7 +9,7 @@ reset it: pip compares with != , not <.
 import json
 import pathlib
 
-CORE_REVISION = 16
+CORE_REVISION = 17
 
 _seal = json.loads(
     pathlib.Path(__file__).with_name("seal.json").read_text(encoding="utf-8")

--- a/src/invisible_core/hooks.py
+++ b/src/invisible_core/hooks.py
@@ -483,9 +483,24 @@ def main(
             ran.append("publish gate (no-op)")
         elif rc:
             _say("", err=True)
-            _say(f"REFUSED (gate exit {rc}) - see above. A version whose content "
-                 f"moved needs a NEW version number: a PyPI filename is never "
-                 f"re-uploaded, so a wrong artifact stays wrong forever.", err=True)
+            # ⛔ NO fixed explanation. This used to print "a version whose
+            # content moved needs a NEW version number" for EVERY non-zero
+            # exit, and the gate refuses for several unrelated reasons: a
+            # direct-URL dependency, an empty ledger, a version that went
+            # backwards, an index the ledger does not match. Naming one of
+            # them as though it were the cause sends the reader looking at
+            # the version number while the gate's own verdict, printed just
+            # above, says something else. Measured on 2026-08-31: it cost a
+            # release cycle - the real line was "the index serves 1 version
+            # that the ledger does not record", four lines up.
+            _say(f"REFUSED (gate exit {rc}). The gate printed its own verdict "
+                 f"above - read THAT, not this line: it refuses for several "
+                 f"unrelated reasons and this hook does not know which.",
+                 err=True)
+            _say("  The recurring one is a ledger the index has outrun: the "
+                 "publish workflow opens a `ledger/<version>` PR and cannot "
+                 "merge it itself, so an unmerged one blocks the NEXT "
+                 "release, not its own.", err=True)
             return 1
         else:
             ran.append("publish gate")


### PR DESCRIPTION
The publish gate refuses for several unrelated reasons and the hook printed the same sentence after all of them, naming the version number as the cause.

Measured today, and it cost a release cycle: the tag v26.16.0 was refused, the hook pointed at the version, and the gate own verdict four lines above said "the index serves 1 version that the ledger does not record: 25.16.0" - a ledger PR that had been open for eight hours with its CI in action_required, blocking not its own release but the next one.

The hook now points at the verdict the gate printed and names the recurring case as a hint. CORE_REVISION 16 -> 17.