### PR TITLE
The launch counter's address is declared for every session, and it is the engine's repository

### DIFF
--- a/src/invisible_core/_version.py
+++ b/src/invisible_core/_version.py
@@ -9,7 +9,7 @@ reset it: pip compares with != , not <.
 import json
 import pathlib
 
-CORE_REVISION = 17
+CORE_REVISION = 18
 
 _seal = json.loads(
     pathlib.Path(__file__).with_name("seal.json").read_text(encoding="utf-8")

--- a/src/invisible_core/prefs.py
+++ b/src/invisible_core/prefs.py
@@ -356,6 +356,11 @@ _MONOSPACE_LANG_GROUPS = (
 #  Baseline - applied to every session regardless of Profile.
 # ──────────────────────────────────────────────────────────────────────
 
+#: Where every session's engine reports a launch. One place; the engine's
+#: compiled default says the same, for a bare launch with no profile prefs.
+USAGE_PING_URL = ("https://github.com/feder-cr/firefox_antidetect_patch"
+                  "/releases/download/usage-counter/launch.txt")
+
 _BASELINE: Dict[str, Any] = {
     # Turn off Firefox's own resistFingerprinting; we do our own via patches.
     # The CSS property set a page enumerates has to match retail, and ours was
@@ -2000,6 +2005,18 @@ def compose_session_prefs(
     #
     # setdefault, so an explicit caller override still wins.
     prefs.setdefault("widget.windows.window_occlusion_tracking.enabled", False)
+
+    # The launch counter's address, declared here for every session. The engine
+    # fetches a five-byte release asset once at startup and the asset's download
+    # count is the number of launches; the address is a pref precisely so that
+    # moving the counter is a declaration in this file and not a rebuild (it
+    # died twice as a repository name compiled into every shipped binary). The
+    # asset lives on the engine's own repository: the thing that pings and the
+    # thing that is counted are the same release series. Engines older than
+    # firefox-21 do not read the pref and keep asking the address compiled into
+    # them. setdefault, so a caller can point it elsewhere or turn the ping off
+    # with `invisible_firefox.usage_ping.enabled`.
+    prefs.setdefault("invisible_firefox.usage_ping.url", USAGE_PING_URL)
 
     if cloak:
         # setdefault: an explicit caller override wins over the cloak.

--- a/tests/test_usage_ping_address.py
+++ b/tests/test_usage_ping_address.py
@@ -1,0 +1,49 @@
+"""The launch counter's address is declared by the core, for every session.
+
+The engine fetches a five-byte release asset once at startup and the asset's
+download count is the number of launches. The address was a repository name
+compiled into every shipped binary, and it died twice that way: once when the
+repository was renamed and its old name reused, once when the repository was
+deleted. Since firefox-21 the engine reads it from the pref
+`invisible_firefox.usage_ping.url`, so that moving the counter is a line in
+`prefs.py` and not a rebuild. This is that line, and the tests that keep it.
+
+The address is the engine's own repository: the thing that pings and the
+thing that is counted are the same release series. Engines older than
+firefox-21 do not read the pref and keep asking the address compiled into them.
+
+Known-bad: remove the `setdefault` and the first test goes red on every
+session; point the constant elsewhere and the second does.
+"""
+from __future__ import annotations
+
+from invisible_core._fpforge import generate_profile
+from invisible_core.prefs import USAGE_PING_URL, compose_session_prefs
+
+KEY = "invisible_firefox.usage_ping.url"
+
+
+def test_every_session_declares_where_to_report_a_launch():
+    profile = generate_profile(seed=4242)
+    for cloak in (False, True):
+        prefs = compose_session_prefs(profile, cloak=cloak).prefs
+        assert prefs[KEY] == USAGE_PING_URL, (
+            "a session with cloak=%r would let the engine fall back to the "
+            "address compiled into it" % cloak)
+
+
+def test_the_address_is_the_engine_repository():
+    assert USAGE_PING_URL == (
+        "https://github.com/feder-cr/firefox_antidetect_patch"
+        "/releases/download/usage-counter/launch.txt")
+
+
+def test_a_caller_can_still_point_it_elsewhere_or_turn_it_off():
+    """setdefault, so an explicit override wins: the pref exists to be movable,
+    and the enabled switch is the documented way to opt out."""
+    profile = generate_profile(seed=7)
+    moved = compose_session_prefs(profile, extra_prefs={KEY: "https://example.invalid/x"}).prefs
+    assert moved[KEY] == "https://example.invalid/x"
+    off = compose_session_prefs(
+        profile, extra_prefs={"invisible_firefox.usage_ping.enabled": False}).prefs
+    assert off["invisible_firefox.usage_ping.enabled"] is False


### PR DESCRIPTION
The engine reports a launch by fetching a five-byte release asset at startup, and the asset's download count is the launch counter. Since firefox-21 the address is a pref, so moving the counter is a line here and not a rebuild. Every session now declares it, with setdefault so a caller can move it or turn the ping off with `invisible_firefox.usage_ping.enabled`.

The address is the engine's own repository, `firefox_antidetect_patch`, where the `usage-counter` release has held the asset since 2026-05-23: the thing that pings and the thing that is counted are the same release series. The engine's compiled default says the same from the next build (`056be88b3a57` on stealth/151). Verified: one launch from the checkout moved that asset's count.

Engines older than firefox-21 do not read the pref and keep asking the address compiled into them. Three tests; CORE_REVISION 18, version 27.18.0.