### PR TITLE
Orphaned .tmp trees in the engine cache are swept on every ensure_binary

### DIFF
--- a/src/invisible_core/_version.py
+++ b/src/invisible_core/_version.py
@@ -9,7 +9,7 @@ reset it: pip compares with != , not <.
 import json
 import pathlib
 
-CORE_REVISION = 18
+CORE_REVISION = 19
 
 _seal = json.loads(
     pathlib.Path(__file__).with_name("seal.json").read_text(encoding="utf-8")

--- a/src/invisible_core/download.py
+++ b/src/invisible_core/download.py
@@ -15,6 +15,7 @@ import zipfile
 from pathlib import Path
 
 import platformdirs
+import psutil
 import requests
 
 from .constants import (
@@ -338,6 +339,40 @@ def _adopt_existing_cache(seal: Seal, asset: Asset, version_dir: Path) -> Path |
     return None
 
 
+def sweep_orphaned_tmp(root: Path | None = None, alive=None) -> list:
+    """Remove the `.tmp-<tag>-<pid>` trees left by downloads whose process is gone.
+
+    A download extracts into a directory named after its pid and, when it
+    starts again, removes only that one. A process killed during `verifying`
+    or `extracting` therefore leaves up to the whole tree behind, and until
+    this existed nothing ever looked at it again. The MCP server's prefetch
+    (0.13.0) made the case ordinary: a client that closes the server in the
+    first minute of its first session kills a download in flight.
+
+    A tree whose pid is alive belongs to a download in flight, in this process
+    or another, and is left alone. A reused pid keeps an orphan for one more
+    round, which is the conservative side. Returns what was removed.
+    """
+    root = root or cache_root()
+    if not root.is_dir():
+        return []
+    alive = alive or psutil.pid_exists
+    removed = []
+    for candidate in root.iterdir():
+        if not candidate.is_dir() or not candidate.name.startswith(".tmp-"):
+            continue
+        pid_text = candidate.name.rsplit("-", 1)[-1]
+        if not pid_text.isdigit():
+            continue
+        pid = int(pid_text)
+        if pid == os.getpid() or alive(pid):
+            continue
+        shutil.rmtree(candidate, ignore_errors=True)
+        if not candidate.exists():
+            removed.append(candidate)
+    return removed
+
+
 def ensure_binary(version: str | None = None, progress=None, status=None,
                   *, seal: Seal | None = None) -> Path:
     """Return a verified path to the sealed Firefox executable. Download if needed.
@@ -413,6 +448,10 @@ def ensure_binary(version: str | None = None, progress=None, status=None,
     asset = seal.asset_for(plat, platform.machine())
     version_dir = cache_dir_for_seal(seal)
     entry = version_dir / asset.entry_rel
+
+    # On every call, warm path included: a cache that never misses again would
+    # otherwise keep a killed download's tree for good.
+    sweep_orphaned_tmp(cache_root())
 
     stamp = read_stamp(version_dir)
     if stamp and stamp.get("seal_digest") == seal.digest and entry.exists():

--- a/tests/test_seal_cache.py
+++ b/tests/test_seal_cache.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import platform
+import subprocess
 import sys
 import zipfile
 from pathlib import Path
@@ -238,6 +239,26 @@ def test_stamped_matching_tree_is_served_with_no_network(cache, no_network, seal
     entry = build_tree(version_dir)
     stamp_for(version_dir, sealed)
     assert ensure_binary(seal=sealed) == entry
+
+
+def test_an_orphaned_tmp_tree_is_swept_on_the_warm_path(cache, no_network, sealed):
+    """A download killed during extraction left its `.tmp-<tag>-<pid>` tree in
+    the cache root for good, because only a fresh download by the SAME pid
+    ever removed it. The sweep runs on every call, warm path included, so a
+    cache that never misses again is still cleaned. The pid is one that has
+    provably exited: a child spawned and waited for here."""
+    version_dir = cache_dir_for_seal(sealed)
+    entry = build_tree(version_dir)
+    stamp_for(version_dir, sealed)
+    gone = subprocess.Popen([sys.executable, "-c", "pass"])
+    gone.wait()
+    orphan = cache / (".tmp-%s-%d" % (sealed.tag, gone.pid))
+    (orphan / "firefox").mkdir(parents=True)
+    (orphan / "firefox" / "omni.ja").write_bytes(b"half-extracted")
+
+    assert ensure_binary(seal=sealed) == entry
+
+    assert not orphan.exists(), "the orphan survived a warm ensure_binary"
 
 
 # --------------------------------------------------------- adoption and D5

--- a/tests/test_tmp_sweep.py
+++ b/tests/test_tmp_sweep.py
@@ -1,0 +1,79 @@
+"""Orphaned `.tmp-<tag>-<pid>` trees are swept, and only those.
+
+A download extracts into a directory named after its pid and, when it starts
+again, removes only that one. A process killed during `verifying` or
+`extracting` therefore left up to the whole tree behind, and nothing ever
+looked at it again. The MCP server's prefetch made the case ordinary: a client
+that closes the server during the first minute of its first session kills a
+download in flight.
+
+The known-bad half matters as much as the sweep: this process's own tree, a
+live process's tree, and anything not named after a pid must all survive.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from invisible_core.download import sweep_orphaned_tmp
+
+
+def _tree(root: Path, name: str) -> Path:
+    d = root / name
+    (d / "firefox").mkdir(parents=True)
+    (d / "firefox" / "omni.ja").write_bytes(b"half-extracted")
+    return d
+
+
+@pytest.mark.unit
+def test_a_dead_pids_tree_is_removed(tmp_path):
+    orphan = _tree(tmp_path, ".tmp-firefox-27-999999")
+
+    removed = sweep_orphaned_tmp(tmp_path, alive=lambda pid: False)
+
+    assert removed == [orphan]
+    assert not orphan.exists()
+
+
+@pytest.mark.unit
+def test_this_processs_own_tree_is_kept_whatever_the_liveness_check_says(tmp_path):
+    mine = _tree(tmp_path, ".tmp-firefox-27-%d" % os.getpid())
+
+    assert sweep_orphaned_tmp(tmp_path, alive=lambda pid: False) == []
+    assert mine.exists()
+
+
+@pytest.mark.unit
+def test_a_live_pids_tree_is_a_download_in_flight_and_is_kept(tmp_path):
+    theirs = _tree(tmp_path, ".tmp-firefox-27-4242")
+
+    assert sweep_orphaned_tmp(tmp_path, alive=lambda pid: pid == 4242) == []
+    assert theirs.exists()
+
+
+@pytest.mark.unit
+def test_nothing_that_is_not_a_pid_named_tmp_tree_is_touched(tmp_path):
+    engine = _tree(tmp_path, "firefox-27_151.0_20260904160921")
+    odd = _tree(tmp_path, ".tmp-notapid")
+    stray_file = tmp_path / ".tmp-firefox-27-777"
+    stray_file.write_bytes(b"a file, not a tree")
+
+    assert sweep_orphaned_tmp(tmp_path, alive=lambda pid: False) == []
+    assert engine.exists() and odd.exists() and stray_file.exists()
+
+
+@pytest.mark.unit
+def test_a_missing_root_is_not_an_error(tmp_path):
+    assert sweep_orphaned_tmp(tmp_path / "nowhere") == []
+
+
+@pytest.mark.unit
+def test_the_default_liveness_check_keeps_the_parent_process(tmp_path):
+    """The default `alive` is psutil's. The parent of this test process is
+    alive by construction, so its tree must survive a real check."""
+    parent = _tree(tmp_path, ".tmp-firefox-27-%d" % os.getppid())
+
+    assert sweep_orphaned_tmp(tmp_path) == []
+    assert parent.exists()


### PR DESCRIPTION
A download extracts into cache_root()/.tmp-<tag>-<pid> and, when it starts again, removes only the tree of its own pid. A process killed during verifying or extracting left up to the whole tree behind, and nothing ever looked at it again. The MCP server 0.13.0 made the case ordinary by starting the download with the process.

sweep_orphaned_tmp removes the trees whose pid is no longer alive (psutil, already a dependency) and keeps everything else: this process own tree, a live pid tree, anything not named after a pid. ensure_binary calls it on every call, warm path included.

Six unit tests and one on the warm path with the pid of a child that has provably exited. Three known-bad mutations, each killed. Core revision 18 to 19.